### PR TITLE
[FIX]BUG-get-schedule-timezone

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -171,7 +171,6 @@ describe('Test /api/group endpoints', () => {
           {
             "byweekday": "", "content": "test-content16", "freq": "DAILY", "groupId": 1, "id": 16, "interval": 1, "recurrence": 1,
             "recurrenceDateList": [
-              { "endDateTime": "2023-04-01T00:00:00.000Z", "startDateTime": "2023-03-15T12:00:00.000Z" },
               { "endDateTime": "2023-04-02T00:00:00.000Z", "startDateTime": "2023-03-16T12:00:00.000Z" },
               { "endDateTime": "2023-04-03T00:00:00.000Z", "startDateTime": "2023-03-17T12:00:00.000Z" },
               { "endDateTime": "2023-04-04T00:00:00.000Z", "startDateTime": "2023-03-18T12:00:00.000Z" },
@@ -195,7 +194,6 @@ describe('Test /api/group endpoints', () => {
           {
             "byweekday": "", "content": "test-content18", "freq": "MONTHLY", "groupId": 1, "id": 18, "interval": 1, "recurrence": 1,
             "recurrenceDateList": [
-              { "endDateTime": "2023-04-01T00:00:00.000Z", "startDateTime": "2023-03-15T12:00:00.000Z" },
               { "endDateTime": "2023-05-02T00:00:00.000Z", "startDateTime": "2023-04-15T12:00:00.000Z" },
             ],
             "title": "test-title18", "until": "2025-01-01T00:00:00.000Z",
@@ -213,13 +211,6 @@ describe('Test /api/group endpoints', () => {
               { "endDateTime": "2023-05-01T23:59:59.000Z", "startDateTime": "2023-04-30T23:59:59.000Z" },
             ],
             "title": "test-title21", "until": "2025-01-01T00:00:00.000Z",
-          },
-          {
-            "byweekday": "", "content": "test-content23", "freq": "YEARLY", "groupId": 1, "id": 23, "interval": 1, "recurrence": 1,
-            "recurrenceDateList": [
-              { "endDateTime": "2023-04-01T00:00:00.000Z", "startDateTime": "2023-03-15T00:00:00.000Z" },
-            ],
-            "title": "test-title23", "until": "2025-01-01T00:00:00.000Z",
           },
         ],
       };

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -106,7 +106,6 @@ describe('Test /api/user endpoints', () => {
           {
             "byweekday": "", "content": "test-content16", "freq": "DAILY", "id": 16, "interval": 1, "recurrence": 1,
             "recurrenceDateList": [
-              { "endDateTime": "2023-04-01T00:00:00.000Z", "startDateTime": "2023-03-15T12:00:00.000Z" },
               { "endDateTime": "2023-04-02T00:00:00.000Z", "startDateTime": "2023-03-16T12:00:00.000Z" },
               { "endDateTime": "2023-04-03T00:00:00.000Z", "startDateTime": "2023-03-17T12:00:00.000Z" },
               { "endDateTime": "2023-04-04T00:00:00.000Z", "startDateTime": "2023-03-18T12:00:00.000Z" },
@@ -130,7 +129,6 @@ describe('Test /api/user endpoints', () => {
           {
             "byweekday": "", "content": "test-content18", "freq": "MONTHLY", "id": 18, "interval": 1, "recurrence": 1,
             "recurrenceDateList": [
-              { "endDateTime": "2023-04-01T00:00:00.000Z", "startDateTime": "2023-03-15T12:00:00.000Z" },
               { "endDateTime": "2023-05-02T00:00:00.000Z", "startDateTime": "2023-04-15T12:00:00.000Z" },
             ],
             "title": "test-title18", "until": "2025-01-01T00:00:00.000Z",
@@ -148,13 +146,6 @@ describe('Test /api/user endpoints', () => {
               { "endDateTime": "2023-05-01T23:59:59.000Z", "startDateTime": "2023-04-30T23:59:59.000Z" },
             ],
             "title": "test-title21", "until": "2025-01-01T00:00:00.000Z",
-          },
-          {
-            "byweekday": "", "content": "test-content23", "freq": "YEARLY", "id": 23, "interval": 1, "recurrence": 1,               
-            "recurrenceDateList": [
-              { "endDateTime": "2023-04-01T00:00:00.000Z", "startDateTime": "2023-03-15T00:00:00.000Z" },
-            ],
-            "title": "test-title23", "until": "2025-01-01T00:00:00.000Z",
           },
         ],
       };

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -23,13 +23,10 @@ async function getUserPersonalMonthSchedule(req, res, next) {
     const { user_id: userID } = req.params;
     const { date: dateString } = req.query;
 
-    // moment 라이브러리를 사용하여 생성된 Date 객체는
-    // 로컬 타임존에 따라 자동으로 변환될 수 있음. 따라서 startUTC, endUTC로 다시 변환해줌.
     const start = moment.utc(dateString, 'YYYY-MM').startOf('month').toDate();
     const end = moment.utc(start).endOf('month').toDate();
-    const startUTC = new Date(start.getTime() + start.getTimezoneOffset() * 60000);
-    const endUTC = new Date(end.getTime() + start.getTimezoneOffset() * 60000);
-    const schedule = await PersonalSchedule.getSchedule(userID, start, end, startUTC, endUTC);
+
+    const schedule = await PersonalSchedule.getSchedule(userID, start, end);
     if (schedule === null) throw new ApiError();
     return res.status(200).json(schedule);
   } catch (err) {
@@ -47,9 +44,8 @@ async function getUserPersonalDaySchedule(req, res, next) {
 
     const start = moment.utc(dateString, 'YYYY-MM-DD').startOf('day').toDate();
     const end = moment.utc(start).endOf('day').toDate();
-    const startUTC = new Date(start.getTime() + start.getTimezoneOffset() * 60000);
-    const endUTC = new Date(end.getTime() + start.getTimezoneOffset() * 60000);
-    const schedule = await PersonalSchedule.getSchedule(userID, start, end, startUTC, endUTC);
+
+    const schedule = await PersonalSchedule.getSchedule(userID, start, end);
     if (schedule === null) throw new ApiError();
     return res.status(200).json(schedule);
   } catch (err) {


### PR DESCRIPTION
# 설명
1. **fix local timezone 관련 문제 해결** #74 
2. **`endDateTime`이 특정 구간의 `시작점과 동일`한 경우에는 select하지 않도록 수정.**
# 해결 방법
1. 쿼리 대입 직전에 **Date타입의 변수를 문자열로 변환**하여 넘겨주도록 함.
기존의 **Date**타입의 변수는 **local timezone**의 시간대로 **자동으로 변환**이 이루어져 문제가 있었지만, 
**문자열**은 해당 과정에서 **데이터에 아무런 변환도 이뤄지지 않으므로** 올바른 결과값을 얻어낼 수 있었음.
![제목 없음](https://github.com/Selody-project/Backend/assets/81506668/e4e072df-a5a1-4949-86a5-32b0e3ab2093)
2. **rrule.between 메소드**를 사용할 때에 **1 milliseconds 값을 빼주는 과정**을 삭제
![제목 없음](https://github.com/Selody-project/Backend/assets/81506668/55c2632f-66d7-4f97-b6e7-a306560ab5b2)

