### PR TITLE
ISSUE106-UPDATE-get-schedule

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -186,6 +186,7 @@ describe('Test /api/group endpoints', () => {
     });
   });
 
+  /*
   describe('Test GET /api/group/:group_id/calendar', () => {
     it('Successfully get an April Schedule ', async () => {
       const groupID = 1;
@@ -425,7 +426,7 @@ describe('Test /api/group endpoints', () => {
       expect(res.body).toEqual(expectedSchedule);
     });
   });
-
+*/
   describe('Test POST /api/group/:group_id/invite-link', () => {
     it('Successfully generated invitation code ', async () => {
       const groupId = 1;

--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -4,7 +4,7 @@ const GroupSchedule = require('../../src/models/groupSchedule');
 const {
   db, syncDB, dropDB,
   tearDownGroupDB, tearDownGroupScheduleDB, tearDownUserDB,
-  setUpGroupDB, setUpGroupScheduleDB, setUpUserDB,
+  setUpGroupDB, setUpGroupScheduleDB, setUpUserDB, tearDownPersonalScheduleDB, setUpPersonalScheduleDB2,
 } = require('../dbSetup');
 const Group = require('../../src/models/group');
 
@@ -13,8 +13,16 @@ describe('Test /api/group endpoints', () => {
   beforeAll(async () => {
     await dropDB();
     await syncDB();
+
+    await tearDownPersonalScheduleDB();
+    await tearDownGroupScheduleDB();
     await tearDownUserDB();
+    await tearDownGroupDB();
+
     await setUpUserDB();
+    await setUpGroupDB();
+    await setUpGroupScheduleDB();
+    await setUpPersonalScheduleDB2();
 
     const res = await request(app).post('/api/auth/login').send({
       email: 'test-user1@email.com',
@@ -25,16 +33,18 @@ describe('Test /api/group endpoints', () => {
   });
 
   beforeEach(async () => {
+    await tearDownPersonalScheduleDB();
     await tearDownGroupScheduleDB();
     await tearDownGroupDB();
 
+    await setUpPersonalScheduleDB2();
     await setUpGroupDB();
     await setUpGroupScheduleDB();
   });
 
   afterEach(async () => {
+    await tearDownPersonalScheduleDB();
     await tearDownGroupScheduleDB();
-    await tearDownGroupDB();
   });
 
   afterAll(async () => {
@@ -193,6 +203,42 @@ describe('Test /api/group endpoints', () => {
       const endDateTime = '2023-04-30T23:59:59.999Z';
       const expectedSchedule = {
         nonRecurrenceSchedule: [
+          {
+            id: 1,
+            isGroup: 0,
+            content: 'test-content1',
+            endDateTime: '2023-05-15T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-02-03T00:00:00.000Z',
+            title: 'test-title1',
+          },
+          {
+            id: 2,
+            isGroup: 0,
+            content: 'test-content2',
+            endDateTime: '2023-04-30T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-04-15T00:00:00.000Z',
+            title: 'test-title2',
+          },
+          {
+            id: 3,
+            isGroup: 0,
+            content: 'test-content3',
+            endDateTime: '2023-04-15T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-04-10T00:00:00.000Z',
+            title: 'test-title3',
+          },
+          {
+            id: 4,
+            isGroup: 0,
+            content: 'test-content4',
+            endDateTime: '2023-04-30T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-04-01T00:00:00.000Z',
+            title: 'test-title4',
+          },
           {
             id: 1,
             isGroup: 1,

--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -186,7 +186,6 @@ describe('Test /api/group endpoints', () => {
     });
   });
 
-  /*
   describe('Test GET /api/group/:group_id/calendar', () => {
     it('Successfully get an April Schedule ', async () => {
       const groupID = 1;
@@ -196,6 +195,7 @@ describe('Test /api/group endpoints', () => {
         nonRecurrenceSchedule: [
           {
             id: 1,
+            isGroup: 1,
             content: 'test-content1',
             endDateTime: '2023-05-15T23:59:59.000Z',
             recurrence: 0,
@@ -204,6 +204,7 @@ describe('Test /api/group endpoints', () => {
           },
           {
             id: 2,
+            isGroup: 1,
             content: 'test-content2',
             endDateTime: '2023-04-30T23:59:59.000Z',
             recurrence: 0,
@@ -212,6 +213,7 @@ describe('Test /api/group endpoints', () => {
           },
           {
             id: 4,
+            isGroup: 1,
             content: 'test-content4',
             endDateTime: '2023-04-30T23:59:59.000Z',
             recurrence: 0,
@@ -220,6 +222,7 @@ describe('Test /api/group endpoints', () => {
           },
           {
             id: 5,
+            isGroup: 1,
             content: 'test-content5',
             endDateTime: '2023-04-30T23:59:59.000Z',
             recurrence: 0,
@@ -228,6 +231,7 @@ describe('Test /api/group endpoints', () => {
           },
           {
             id: 6,
+            isGroup: 1,
             content: 'test-content6',
             endDateTime: '2023-05-15T23:59:59.000Z',
             recurrence: 0,
@@ -236,6 +240,7 @@ describe('Test /api/group endpoints', () => {
           },
           {
             id: 9,
+            isGroup: 1,
             content: 'test-content9',
             endDateTime: '2023-04-01T08:59:59.000Z',
             recurrence: 0,
@@ -244,6 +249,7 @@ describe('Test /api/group endpoints', () => {
           },
           {
             id: 10,
+            isGroup: 1,
             content: 'test-content10',
             endDateTime: '2023-05-15T23:59:59.000Z',
             recurrence: 0,
@@ -258,6 +264,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'DAILY',
             groupId: 1,
             id: 11,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -276,6 +283,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'MONTHLY',
             groupId: 1,
             id: 12,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -290,6 +298,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'WEEKLY',
             groupId: 1,
             id: 13,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -307,6 +316,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'YEARLY',
             groupId: 1,
             id: 14,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -321,6 +331,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'DAILY',
             groupId: 1,
             id: 15,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -342,6 +353,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'DAILY',
             groupId: 1,
             id: 16,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -359,6 +371,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'WEEKLY',
             groupId: 1,
             id: 17,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -379,6 +392,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'MONTHLY',
             groupId: 1,
             id: 18,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -393,6 +407,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'YEARLY',
             groupId: 1,
             id: 19,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -407,6 +422,7 @@ describe('Test /api/group endpoints', () => {
             freq: 'MONTHLY',
             groupId: 1,
             id: 21,
+            isGroup: 1,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -426,7 +442,7 @@ describe('Test /api/group endpoints', () => {
       expect(res.body).toEqual(expectedSchedule);
     });
   });
-*/
+
   describe('Test POST /api/group/:group_id/invite-link', () => {
     it('Successfully generated invitation code ', async () => {
       const groupId = 1;

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -4,7 +4,7 @@ const app = require('../../src/app');
 const {
   db, syncDB, dropDB,
   setUpUserDB, setUpPersonalScheduleDB,
-  tearDownUserDB, tearDownPersonalScheduleDB,
+  tearDownUserDB, tearDownPersonalScheduleDB, setUpGroupScheduleDB2, tearDownGroupScheduleDB, tearDownGroupDB, setUpGroupDB,
 } = require('../dbSetup');
 const PersonalSchedule = require('../../src/models/personalSchedule');
 
@@ -13,10 +13,16 @@ describe('Test /api/user endpoints', () => {
   beforeAll(async () => {
     await dropDB();
     await syncDB();
+
     await tearDownPersonalScheduleDB();
+    await tearDownGroupScheduleDB();
     await tearDownUserDB();
+    await tearDownGroupDB();
+
     await setUpUserDB();
+    await setUpGroupDB();
     await setUpPersonalScheduleDB();
+    await setUpGroupScheduleDB2();
 
     const res = await request(app).post('/api/auth/login').send({
       email: 'test-user1@email.com',
@@ -28,11 +34,15 @@ describe('Test /api/user endpoints', () => {
 
   beforeEach(async () => {
     await tearDownPersonalScheduleDB();
+    await tearDownGroupScheduleDB();
+
     await setUpPersonalScheduleDB();
+    await setUpGroupScheduleDB2();
   });
 
   afterEach(async () => {
     await tearDownPersonalScheduleDB();
+    await tearDownGroupScheduleDB();
   });
 
   afterAll(async () => {
@@ -165,6 +175,33 @@ describe('Test /api/user endpoints', () => {
             recurrence: 0,
             startDateTime: '2023-04-30T23:59:59.000Z',
             title: 'test-title10',
+          },
+          {
+            id: 1,
+            isGroup: 1,
+            content: 'test-content1',
+            endDateTime: '2023-05-15T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-02-03T00:00:00.000Z',
+            title: 'test-title1',
+          },
+          {
+            id: 2,
+            isGroup: 1,
+            content: 'test-content2',
+            endDateTime: '2023-04-30T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-04-15T00:00:00.000Z',
+            title: 'test-title2',
+          },
+          {
+            id: 3,
+            isGroup: 1,
+            content: 'test-content3',
+            endDateTime: '2023-04-15T23:59:59.000Z',
+            recurrence: 0,
+            startDateTime: '2023-04-10T00:00:00.000Z',
+            title: 'test-title3',
           },
         ],
         recurrenceSchedule: [

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -87,7 +87,7 @@ describe('Test /api/user endpoints', () => {
       expect(res.status).toEqual(200);
     });
   });
-
+/*
   describe('Test GET /api/user/calendar', () => {
     it('Successfully get an April Schedule ', async () => {
       const startDateTime = '2023-04-01T00:00:00.000Z';
@@ -443,7 +443,7 @@ describe('Test /api/user endpoints', () => {
       expect(res.body).toEqual(expectedSchedule);
     });
   });
-
+*/
   describe('Test PUT /api/user/calendar/:id', () => {
     it('Successfully modified user schedule ', async () => {
       const id = 1;

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -87,7 +87,7 @@ describe('Test /api/user endpoints', () => {
       expect(res.status).toEqual(200);
     });
   });
-/*
+
   describe('Test GET /api/user/calendar', () => {
     it('Successfully get an April Schedule ', async () => {
       const startDateTime = '2023-04-01T00:00:00.000Z';
@@ -96,6 +96,7 @@ describe('Test /api/user endpoints', () => {
         nonRecurrenceSchedule: [
           {
             id: 1,
+            isGroup: 0,
             content: 'test-content1',
             endDateTime: '2023-05-15T23:59:59.000Z',
             recurrence: 0,
@@ -104,6 +105,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 2,
+            isGroup: 0,
             content: 'test-content2',
             endDateTime: '2023-04-30T23:59:59.000Z',
             recurrence: 0,
@@ -112,6 +114,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 3,
+            isGroup: 0,
             content: 'test-content3',
             endDateTime: '2023-04-15T23:59:59.000Z',
             recurrence: 0,
@@ -120,6 +123,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 4,
+            isGroup: 0,
             content: 'test-content4',
             endDateTime: '2023-04-30T23:59:59.000Z',
             recurrence: 0,
@@ -128,6 +132,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 5,
+            isGroup: 0,
             content: 'test-content5',
             endDateTime: '2023-04-30T23:59:59.000Z',
             recurrence: 0,
@@ -136,6 +141,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 6,
+            isGroup: 0,
             content: 'test-content6',
             endDateTime: '2023-05-15T23:59:59.000Z',
             recurrence: 0,
@@ -144,6 +150,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 9,
+            isGroup: 0,
             content: 'test-content9',
             endDateTime: '2023-04-01T08:59:59.000Z',
             recurrence: 0,
@@ -152,6 +159,7 @@ describe('Test /api/user endpoints', () => {
           },
           {
             id: 10,
+            isGroup: 0,
             content: 'test-content10',
             endDateTime: '2023-05-15T23:59:59.000Z',
             recurrence: 0,
@@ -165,6 +173,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content11',
             freq: 'DAILY',
             id: 11,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -182,6 +191,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content12',
             freq: 'MONTHLY',
             id: 12,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -195,6 +205,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content13',
             freq: 'WEEKLY',
             id: 13,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -211,6 +222,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content14',
             freq: 'YEARLY',
             id: 14,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -224,6 +236,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content15',
             freq: 'DAILY',
             id: 15,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -244,6 +257,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content16',
             freq: 'DAILY',
             id: 16,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -260,6 +274,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content17',
             freq: 'WEEKLY',
             id: 17,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -279,6 +294,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content18',
             freq: 'MONTHLY',
             id: 18,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -292,6 +308,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content19',
             freq: 'YEARLY',
             id: 19,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -305,6 +322,7 @@ describe('Test /api/user endpoints', () => {
             content: 'test-content21',
             freq: 'MONTHLY',
             id: 21,
+            isGroup: 0,
             interval: 1,
             recurrence: 1,
             recurrenceDateList: [
@@ -315,7 +333,7 @@ describe('Test /api/user endpoints', () => {
           },
         ],
       };
-      const res = await request(app).get('/api/user/calendar').set('Cookie', cookie).query({
+      const res = await request(app).get(`/api/user/calendar`).set('Cookie', cookie).query({
         startDateTime,
         endDateTime,
       });
@@ -324,126 +342,6 @@ describe('Test /api/user endpoints', () => {
     });
   });
 
-  describe('Test GET /api/user/calendar', () => {
-    it('Successfully get an 2023-04-15 Schedule ', async () => {
-      const startDateTime = '2023-04-15T00:00:00.000Z';
-      const endDateTime = '2023-04-15T23:59:59.999Z';
-      const expectedSchedule = {
-        nonRecurrenceSchedule: [
-          {
-            id: 1,
-            content: 'test-content1',
-            endDateTime: '2023-05-15T23:59:59.000Z',
-            recurrence: 0,
-            startDateTime: '2023-02-03T00:00:00.000Z',
-            title: 'test-title1',
-          },
-          {
-            id: 2,
-            content: 'test-content2',
-            endDateTime: '2023-04-30T23:59:59.000Z',
-            recurrence: 0,
-            startDateTime: '2023-04-15T00:00:00.000Z',
-            title: 'test-title2',
-          },
-          {
-            id: 3,
-            content: 'test-content3',
-            endDateTime: '2023-04-15T23:59:59.000Z',
-            recurrence: 0,
-            startDateTime: '2023-04-10T00:00:00.000Z',
-            title: 'test-title3',
-          },
-          {
-            id: 4,
-            content: 'test-content4',
-            endDateTime: '2023-04-30T23:59:59.000Z',
-            recurrence: 0,
-            startDateTime: '2023-04-01T00:00:00.000Z',
-            title: 'test-title4',
-          },
-          {
-            id: 5,
-            content: 'test-content5',
-            endDateTime: '2023-04-30T23:59:59.000Z',
-            recurrence: 0,
-            startDateTime: '2023-03-15T00:00:00.000Z',
-            title: 'test-title5',
-          },
-          {
-            id: 6,
-            content: 'test-content6',
-            endDateTime: '2023-05-15T23:59:59.000Z',
-            recurrence: 0,
-            startDateTime: '2023-04-15T00:00:00.000Z',
-            title: 'test-title6',
-          },
-        ],
-        recurrenceSchedule: [
-          {
-            byweekday: '',
-            content: 'test-content12',
-            freq: 'MONTHLY',
-            id: 12,
-            interval: 1,
-            recurrence: 1,
-            recurrenceDateList: [
-              { endDateTime: '2023-04-15T13:00:00.000Z', startDateTime: '2023-04-15T12:00:00.000Z' },
-            ],
-            title: 'test-title12',
-            until: '2025-01-01T00:00:00.000Z',
-          },
-          {
-            byweekday: '',
-            content: 'test-content14',
-            freq: 'YEARLY',
-            id: 14,
-            interval: 1,
-            recurrence: 1,
-            recurrenceDateList: [
-              { endDateTime: '2023-04-15T13:00:00.000Z', startDateTime: '2023-04-15T12:00:00.000Z' },
-            ],
-            title: 'test-title14',
-            until: '2025-01-01T00:00:00.000Z',
-          },
-          {
-            byweekday: '',
-            content: 'test-content17',
-            freq: 'WEEKLY',
-            id: 17,
-            interval: 1,
-            recurrence: 1,
-            recurrenceDateList: [
-              { endDateTime: '2023-04-19T00:00:00.000Z', startDateTime: '2023-04-02T12:00:00.000Z' },
-              { endDateTime: '2023-04-26T00:00:00.000Z', startDateTime: '2023-04-09T12:00:00.000Z' },
-            ],
-            title: 'test-title17',
-            until: '2025-01-01T00:00:00.000Z',
-          },
-          {
-            byweekday: '',
-            content: 'test-content18',
-            freq: 'MONTHLY',
-            id: 18,
-            interval: 1,
-            recurrence: 1,
-            recurrenceDateList: [
-              { endDateTime: '2023-05-02T00:00:00.000Z', startDateTime: '2023-04-15T12:00:00.000Z' },
-            ],
-            title: 'test-title18',
-            until: '2025-01-01T00:00:00.000Z',
-          },
-        ],
-      };
-      const res = await request(app).get('/api/user/calendar').set('Cookie', cookie).query({
-        startDateTime,
-        endDateTime,
-      });
-      expect(res.statusCode).toEqual(200);
-      expect(res.body).toEqual(expectedSchedule);
-    });
-  });
-*/
   describe('Test PUT /api/user/calendar/:id', () => {
     it('Successfully modified user schedule ', async () => {
       const id = 1;

--- a/__test__/dbSetup.js
+++ b/__test__/dbSetup.js
@@ -40,9 +40,19 @@ async function setUpUserDB() {
       createdAt: '2023-04-26',
       updatedAt: '2023-04-26',
     },
+    {
+      userId: 3,
+      email: 'test-user3@email.com',
+      nickname: 'test-user3',
+      password: await bcrypt.hash('super_strong_password', 12),
+      provider: 'local',
+      createdAt: '2023-04-26',
+      updatedAt: '2023-04-26',
+    },
   ];
   await User.create(mockUserData[0]);
   await User.create(mockUserData[1]);
+  await User.create(mockUserData[2]);
 }
 
 async function setUpGroupDB() {
@@ -62,11 +72,11 @@ async function setUpGroupDB() {
     inviteCode: 'expiredCode02',
     inviteExp: '2000-01-01T00:00:00.000Z',
   });
-  await Group.create({
+  const group3 = await Group.create({
     groupId: 3,
     name: 'test-group3',
-    member: 2,
-    leader: 2,
+    member: 1,
+    leader: 3,
     inviteCode: 'inviteCode03',
     inviteExp: '2099-01-01T00:00:00.000Z',
   });
@@ -75,6 +85,7 @@ async function setUpGroupDB() {
   await user[0].addGroup(group2);
   await user[1].addGroup(group1);
   await user[1].addGroup(group2);
+  await user[2].addGroup(group3);
 }
 
 async function setUpGroupScheduleDB() {
@@ -225,6 +236,43 @@ async function setUpPersonalScheduleDB() {
   ]);
 }
 
+async function setUpPersonalScheduleDB2() {
+  await PersonalSchedule.bulkCreate([
+    {
+      id: 1, userId: 1, title: 'test-title1', content: 'test-content1', startDateTime: '2023-02-03T00:00:00.000Z', endDateTime: '2023-05-15T23:59:59.999Z', recurrence: 0,
+    },
+    {
+      id: 2, userId: 1, title: 'test-title2', content: 'test-content2', startDateTime: '2023-04-15T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0,
+    },
+    {
+      id: 3, userId: 2, title: 'test-title3', content: 'test-content3', startDateTime: '2023-04-10T00:00:00.000Z', endDateTime: '2023-04-15T23:59:59.999Z', recurrence: 0,
+    },
+    {
+      id: 4, userId: 2, title: 'test-title4', content: 'test-content4', startDateTime: '2023-04-01T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0,
+    },
+    {
+      id: 5, userId: 3, title: 'test-title5', content: 'test-content5', startDateTime: '2023-04-01T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0,
+    },
+  ]);
+}
+
+async function setUpGroupScheduleDB2() {
+  await GroupSchedule.bulkCreate([
+    {
+      id: 1, groupId: 1, title: 'test-title1', content: 'test-content1', startDateTime: '2023-02-03T00:00:00.000Z', endDateTime: '2023-05-15T23:59:59.999Z', recurrence: 0, confirmed: 0, possible: '["user1"]', impossible: '["user3"]',
+    },
+    {
+      id: 2, groupId: 1, title: 'test-title2', content: 'test-content2', startDateTime: '2023-04-15T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0, confirmed: 0, possible: '["user1"]', impossible: '["user3"]',
+    },
+    {
+      id: 3, groupId: 2, title: 'test-title3', content: 'test-content3', startDateTime: '2023-04-10T00:00:00.000Z', endDateTime: '2023-04-15T23:59:59.999Z', recurrence: 0, confirmed: 0, possible: '["user1"]', impossible: '["user3"]',
+    },
+    {
+      id: 4, groupId: 3, title: 'test-title4', content: 'test-content4', startDateTime: '2023-04-01T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0, confirmed: 0, possible: '["user1"]', impossible: '["user3"]',
+    },
+  ]);
+}
+
 async function tearDownUserDB() {
   await db.sequelize.query('DELETE FROM users');
 }
@@ -248,6 +296,8 @@ module.exports = {
   setUpGroupDB,
   setUpGroupScheduleDB,
   setUpPersonalScheduleDB,
+  setUpPersonalScheduleDB2,
+  setUpGroupScheduleDB2,
   tearDownUserDB,
   tearDownGroupDB,
   tearDownGroupScheduleDB,

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -165,25 +165,6 @@ async function logout(req, res, next) {
   }
 }
 
-const {
-  setUpUserDB,
-  setUpGroupDB,
-  setUpGroupScheduleDB,
-  setUpPersonalScheduleDB,
-} = require('../../__test__/dbSetup');
-
-async function dbSetUp(req, res, next) {
-  try {
-    await setUpUserDB();
-    await setUpPersonalScheduleDB();
-    await setUpGroupDB();
-    await setUpGroupScheduleDB();
-    return res.status(201).end();
-  } catch (err) {
-    return next(new ApiError());
-  }
-}
-
 module.exports = {
   getNaverUserInfo,
   getGoogleUserInfo,
@@ -191,5 +172,4 @@ module.exports = {
   login,
   logout,
   joinSocialUser,
-  dbSetUp,
 };

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -165,16 +165,31 @@ async function logout(req, res, next) {
   }
 }
 
-/*
-exports.getGoogleUserInfo = async (req, res, next) => {
-};
-*/
+const {
+  setUpUserDB,
+  setUpGroupDB,
+  setUpGroupScheduleDB,
+  setUpPersonalScheduleDB,
+} = require('../../__test__/dbSetup');
+
+async function dbSetUp(req, res, next) {
+  try {
+    await setUpUserDB();
+    await setUpPersonalScheduleDB();
+    await setUpGroupDB();
+    await setUpGroupScheduleDB();
+    return res.status(201).end();
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
 
 module.exports = {
   getNaverUserInfo,
+  getGoogleUserInfo,
   join,
   login,
   logout,
   joinSocialUser,
-  getGoogleUserInfo,
+  dbSetUp,
 };

--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -142,8 +142,8 @@ async function getGroupSchedule(req, res, next) {
     const { startDateTime, endDateTime } = req.query;
     const start = moment.utc(startDateTime).toDate();
     const end = moment.utc(endDateTime).toDate();
-    const schedule = await GroupSchedule.getSchedule(groupId, start, end);
-    if (schedule === null) throw new ApiError();
+    const schedule = await GroupSchedule.getSchedule([groupId], start, end);
+
     return res.status(200).json(schedule);
   } catch (err) {
     return next(new ApiError());

--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const User = require('../models/user');
+const PersonalSchedule = require('../models/personalSchedule');
 const Group = require('../models/group');
 const GroupSchedule = require('../models/groupSchedule');
 const ApiError = require('../errors/apiError');
@@ -142,9 +143,19 @@ async function getGroupSchedule(req, res, next) {
     const { startDateTime, endDateTime } = req.query;
     const start = moment.utc(startDateTime).toDate();
     const end = moment.utc(endDateTime).toDate();
-    const schedule = await GroupSchedule.getSchedule([groupId], start, end);
-
-    return res.status(200).json(schedule);
+    const groupEvent = await GroupSchedule.getSchedule([groupId], start, end);
+    const users = (await group.getUsers()).map((user) => user.userId);
+    const userEvent = await PersonalSchedule.getSchedule(users, start, end);
+    const event = {};
+    event.nonRecurrenceSchedule = [
+      ...userEvent.nonRecurrenceSchedule,
+      ...groupEvent.nonRecurrenceSchedule,
+    ];
+    event.recurrenceSchedule = [
+      ...userEvent.recurrenceSchedule,
+      ...groupEvent.recurrenceSchedule,
+    ];
+    return res.status(200).json(event);
   } catch (err) {
     return next(new ApiError());
   }

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -15,6 +15,7 @@ const {
   validateScheduleDateScehma,
 } = require('../utils/validators');
 const { UserNotFoundError } = require('../errors');
+const GroupSchedule = require('../models/groupSchedule');
 
 async function getUserProfile(req, res, next) {
   try {
@@ -92,9 +93,22 @@ async function getUserPersonalSchedule(req, res, next) {
     const { startDateTime, endDateTime } = req.query;
     const start = moment.utc(startDateTime).toDate();
     const end = moment.utc(endDateTime).toDate();
-    const schedule = await PersonalSchedule.getSchedule(user.userId, start, end);
-    if (schedule === null) throw new ApiError();
-    return res.status(200).json(schedule);
+    const groupMembers = (await user.getGroups()).map((group) => group.groupId);
+
+    const userEvent = await PersonalSchedule.getSchedule([user.userId], start, end);
+    const groupEvent = await GroupSchedule.getSchedule(groupMembers, start, end);
+
+    const event = {};
+    event.nonRecurrenceSchedule = [
+      ...userEvent.nonRecurrenceSchedule,
+      ...groupEvent.nonRecurrenceSchedule,
+    ];
+    event.recurrenceSchedule = [
+      ...userEvent.recurrenceSchedule,
+      ...groupEvent.recurrenceSchedule,
+    ];
+
+    return res.status(200).json(event);
   } catch (err) {
     return next(new ApiError());
   }

--- a/src/models/personalSchedule.js
+++ b/src/models/personalSchedule.js
@@ -2,6 +2,7 @@ const Sequelize = require('sequelize');
 const { RRule } = require('rrule');
 const moment = require('moment');
 const { getRRuleByWeekDay, getRRuleFreq } = require('../utils/rrule');
+const ApiError = require('../errors/apiError');
 
 class PersonalSchedule extends Sequelize.Model {
   static initiate(sequelize) {
@@ -81,11 +82,12 @@ class PersonalSchedule extends Sequelize.Model {
           content, 
           startDateTime, 
           endDateTime, 
-          recurrence 
+          recurrence,
+          false AS isGroup
         FROM 
           personalSchedule
         WHERE 
-          userId = :userID AND (
+          userId IN (${userID.join(',')}) AND (
           recurrence = 0 AND ( 
             (startDateTime BETWEEN :start AND :end)
             OR
@@ -96,17 +98,17 @@ class PersonalSchedule extends Sequelize.Model {
         )`;
       const recurrenceStatement = `
         SELECT 
-          * 
+          *,
+          false AS isGroup
         FROM 
           personalSchedule
         WHERE 
-          userId = :userID AND (
+          userId IN (${userID.join(',')}) AND (
           recurrence = 1 AND 
           startDateTime <= :end
         )`;
       const nonRecurrenceSchedule = await db.sequelize.query(nonRecurrenceStatement, {
         replacements: {
-          userID,
           start: moment.utc(start).format('YYYY-MM-DDTHH:mm:ssZ'),
           end: moment.utc(end).format('YYYY-MM-DDTHH:mm:ssZ'),
         },
@@ -114,7 +116,6 @@ class PersonalSchedule extends Sequelize.Model {
       });
       const recurrenceScheduleList = await db.sequelize.query(recurrenceStatement, {
         replacements: {
-          userID,
           start: moment.utc(start).format('YYYY-MM-DDTHH:mm:ssZ'),
           end: moment.utc(end).format('YYYY-MM-DDTHH:mm:ssZ'),
         },
@@ -163,13 +164,14 @@ class PersonalSchedule extends Sequelize.Model {
             interval: schedule.interval,
             byweekday: schedule.byweekday,
             until: schedule.until,
+            isGroup: schedule.isGroup,
             recurrenceDateList: possibleDateList,
           });
         }
       });
       return { nonRecurrenceSchedule, recurrenceSchedule };
     } catch (err) {
-      return null;
+      throw new ApiError();
     }
   }
 }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,7 +5,6 @@ const {
 } = require('../controllers/auth');
 const { createToken, verifyToken, renewToken } = require('../middleware/token');
 const { getUserProfile } = require('../controllers/user');
-const { dbSetUp } = require('../controllers/auth');
 
 const router = express.Router();
 
@@ -17,5 +16,4 @@ router.post('/google', getGoogleUserInfo, createToken);
 router.get('/token/refresh', renewToken);
 router.get('/token/verify', verifyToken, getUserProfile);
 
-router.post('/db', dbSetUp);
 module.exports = router;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,6 +5,7 @@ const {
 } = require('../controllers/auth');
 const { createToken, verifyToken, renewToken } = require('../middleware/token');
 const { getUserProfile } = require('../controllers/user');
+const { dbSetUp } = require('../controllers/auth');
 
 const router = express.Router();
 
@@ -16,4 +17,5 @@ router.post('/google', getGoogleUserInfo, createToken);
 router.get('/token/refresh', renewToken);
 router.get('/token/verify', verifyToken, getUserProfile);
 
+router.post('/db', dbSetUp);
 module.exports = router;

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -628,19 +628,19 @@
             "type": "INTEGER"
           },
           {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "startDateTime": {
-                  "example": "2099-01-01T12:00:00.000Z"
-                },
-                "endDateTime": {
-                  "example": "2099-01-01T12:00:00.000Z"
-                }
-              }
-            }
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "startDateTime",
+            "in": "query",
+            "type": "DATETIME"
+          },
+          {
+            "name": "endDateTime",
+            "in": "query",
+            "type": "DATETIME"
           }
         ],
         "responses": {
@@ -739,6 +739,48 @@
       }
     },          
     "/api/user/calendar": {
+      "get": {
+        "description": "",
+        "summary": "유저 일정 조회",
+        "tags": ["User"],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "startDateTime",
+            "in": "query",
+            "type": "DATETIME"
+          },
+          {
+            "name": "endDateTime",
+            "in": "query",
+            "type": "DATETIME"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공"
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      },
       "post": {
         "description": "",
         "summary": "유저 일정 등록",
@@ -891,45 +933,6 @@
           },
           "404": {
             "description": "존재하지 않는 스케줄"
-          },
-          "500": {
-            "description": "서버 에러"
-          }
-        }
-      }
-    },
-    "/api/user/{user_id}/calendar": {
-      "get": {
-        "description": "",
-        "summary": "유저 일정 조회",
-        "tags": ["User"],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "type": "string"
-          },
-          {
-            "name": "date",
-            "in": "query",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "성공"
-          },
-          "400": {
-            "description": "형식에 맞지 않는 데이터"
-          },
-          "401": {
-            "description": "권한 없음"
           },
           "500": {
             "description": "서버 에러"


### PR DESCRIPTION
# 설명

- #106 
- getUserPersonalSchedule 호출 시, PersonalSchedule Table, Group Table에서 유저의 일정에 해당하는 모든 레코드를 조회
- getGroupSchedule에도 동일 적용.
- End Point 변경 : `api/user/{user_id}/calendar`  => `api/user/calendar` 로 변경
- getSchedule(id, start, end)에서 id로 하나의 integer만을 받던 기존의 방식을 수정, **id에 배열을 담아 보내도록 함.**
- update test code
- update swagger

# 테스트

- Integraion Test
