### PR TITLE
ISSUE134-fix-swagger

### DIFF
--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -5,7 +5,7 @@
     "description": "RestFul API 클라이언트 UI",
     "version": "1.0.0"
   },
-  "host": "127.0.0.1:8000",
+  "host": "43.200.173.176:8000",
   "basePath": "/",
   "schemes": [
     "http"


### PR DESCRIPTION
# 설명

- #134
- 기존에 로컬 주소로 설정되어 있던 swagger docs의 주소를 백앤드 서버 주소로 수정.

