### PR TITLE
ISSUE186-fix-get-calendar

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -259,6 +259,7 @@ describe('Test /api/group endpoints', () => {
       const expectedSchedule = {
         accessLevel: 'owner',
         schedule: {
+          earliestDate: '2023-01-15T12:00:00.000Z',
           nonRecurrenceSchedule: [
             {
               id: 1,

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -135,6 +135,7 @@ describe('Test /api/user endpoints', () => {
       const startDateTime = '2023-04-01T00:00:00.000Z';
       const endDateTime = '2023-04-30T23:59:59.999Z';
       const expectedSchedule = {
+        earliestDate : '2023-01-15T12:00:00.000Z',
         nonRecurrenceSchedule: [
           {
             id: 1,

--- a/src/controllers/groupSchedule.js
+++ b/src/controllers/groupSchedule.js
@@ -145,7 +145,12 @@ async function getGroupSchedule(req, res, next) {
       attributes: ['userId'],
     })).map((member) => member.userId);
     const userEvent = await PersonalSchedule.getSchedule(users, start, end);
-    const schedule = {};
+    let schedule;
+    if (userEvent.earliestDate > groupEvent.earliestDate) {
+      schedule = { earliestDate: groupEvent.earliestDate };
+    } else {
+      schedule = { earliestDate: userEvent.earliestDate };
+    }
     schedule.nonRecurrenceSchedule = [
       ...userEvent.nonRecurrenceSchedule,
       ...groupEvent.nonRecurrenceSchedule,

--- a/src/controllers/personalSchedule.js
+++ b/src/controllers/personalSchedule.js
@@ -95,7 +95,12 @@ async function getUserPersonalSchedule(req, res, next) {
     const groups = (await user.getGroups()).map((group) => group.groupId);
     if (groups.length) {
       const groupEvent = await GroupSchedule.getSchedule(groups, start, end);
-      const event = {};
+      let event;
+      if (userEvent.earliestDate > groupEvent.earliestDate) {
+        event = { earliestDate: groupEvent.earliestDate };
+      } else {
+        event = { earliestDate: userEvent.earliestDate };
+      }
       event.nonRecurrenceSchedule = [
         ...userEvent.nonRecurrenceSchedule,
         ...groupEvent.nonRecurrenceSchedule,

--- a/src/models/groupSchedule.js
+++ b/src/models/groupSchedule.js
@@ -74,6 +74,7 @@ class GroupSchedule extends Sequelize.Model {
   static async getSchedule(groupID, start, end) {
     try {
       const db = require('.');
+      let earliestDate = Number.MAX_SAFE_INTEGER;
       const nonRecurrenceStatement = `
       SELECT 
         id,
@@ -114,6 +115,12 @@ class GroupSchedule extends Sequelize.Model {
         },
         type: Sequelize.QueryTypes.SELECT,
       });
+      nonRecurrenceSchedule.forEach((schedule) => {
+        const scheduleDate = new Date(schedule.startDateTime);
+        if (earliestDate > scheduleDate) {
+          earliestDate = scheduleDate;
+        }
+      });
       const recurrenceScheduleList = await db.sequelize.query(recurrenceStatement, {
         replacements: {
           start: moment.utc(start).format('YYYY-MM-DDTHH:mm:ssZ'),
@@ -150,6 +157,9 @@ class GroupSchedule extends Sequelize.Model {
         scheduleDateList.forEach((scheduleDate) => {
           const endDateTime = new Date(scheduleDate.getTime() + scheduleLength);
           if (endDateTime >= start) {
+            if (earliestDate > scheduleDate) {
+              earliestDate = scheduleDate;
+            }
             possibleDateList.push({ startDateTime: scheduleDate, endDateTime });
           }
         });
@@ -169,7 +179,7 @@ class GroupSchedule extends Sequelize.Model {
           });
         }
       });
-      return { nonRecurrenceSchedule, recurrenceSchedule };
+      return { earliestDate, nonRecurrenceSchedule, recurrenceSchedule };
     } catch (err) {
       throw new ApiError();
     }

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -244,6 +244,9 @@
               "properties": {
                 "name": {
                   "example": "string"
+                },
+                "description": {
+                  "example": "test-description"
                 }
               }
             }


### PR DESCRIPTION
# 설명
- #186 
- GET `/api/user/calendar` : 개인 일정 조회
- GET `/api/group/:group_id/calendar` : 그룹 일정 조회
- 위 두 api 결과값에 아래와 같이 earliestDate를 추가
![제목 없음](https://github.com/Selody-project/Backend/assets/81506668/b19a6928-890b-4a6c-92d8-1086d78bffef)

# 테스트
- Integration Test
