### PR TITLE
ISSUE191-fix-delete-group-member

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -1325,7 +1325,7 @@ describe('Test /api/group endpoints', () => {
   describe('Test DELETE /api/group/:group_id/members/:user_id', () => {
     it('Successfully expelled a member. ', async () => {
       const groupId = 1;
-      const userId = 2;
+      const userId = 4;
       const res = (await request(app).delete(`/api/group/${groupId}/members/${userId}`).set('Cookie', cookie));
       expect(res.status).toEqual(204);
     });
@@ -1352,6 +1352,14 @@ describe('Test /api/group endpoints', () => {
       const res = (await request(app).delete(`/api/group/${groupId}/members/${userId}`).set('Cookie', cookie));
       expect(res.status).toEqual(400);
       expect(res.body).toEqual({ error: 'The requested data format is not valid.' });
+    });
+
+    it('Successfully failed to expell a member. (No Ban Permission Error) ', async () => {
+      const groupId = 1;
+      const userId = 2;
+      const res = (await request(app).delete(`/api/group/${groupId}/members/${userId}`).set('Cookie', cookie));
+      expect(res.status).toEqual(403);
+      expect(res.body).toEqual({ error: 'You cannot ban the leader or administrator. ' });
     });
   });
 

--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -11,7 +11,7 @@ const {
   DataFormatError, ApiError,
   UserNotFoundError, GroupNotFoundError,
   UnauthorizedError, ExpiredCodeError,
-  InvalidGroupJoinError, UserIsLeaderError,
+  InvalidGroupJoinError, UserIsLeaderError, NoBanPermission,
 } = require('../errors');
 
 // Validator
@@ -572,6 +572,11 @@ async function deleteGroupMember(req, res, next) {
     const accessLevel = await getAccessLevel(user, group);
     if (accessLevel !== 'owner') {
       return next(new UnauthorizedError());
+    }
+
+    const memberAccessLevel = await getAccessLevel(member, group);
+    if (memberAccessLevel === 'owner' || memberAccessLevel === 'admin') {
+      return next(new NoBanPermission());
     }
 
     await group.removeUser(member);

--- a/src/errors/group/NoBanPermission.js
+++ b/src/errors/group/NoBanPermission.js
@@ -1,0 +1,9 @@
+const ApiError = require('../apiError');
+
+class NoBanPermission extends ApiError {
+  constructor(message) {
+    super(message || 'You cannot ban the leader or administrator. ', 403);
+  }
+}
+
+module.exports = NoBanPermission;

--- a/src/errors/group/index.js
+++ b/src/errors/group/index.js
@@ -1,9 +1,11 @@
 const GroupNotFoundError = require('./GroupNotFoundError');
 const ExpiredCodeError = require('./ExpiredCodeError');
 const InvalidGroupJoinError = require('./InvalidGroupJoinError');
+const NoBanPermission = require('./NoBanPermission');
 
 module.exports = {
   GroupNotFoundError,
   ExpiredCodeError,
   InvalidGroupJoinError,
+  NoBanPermission,
 };

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -641,7 +641,7 @@
             "description": "권한 없음"
           },
           "403": {
-            "description": "수정할 권한이 없음"
+            "description": "수정할 권한이 없음 & 리더 또는 관리자는 추방될 수 없음"
           },
           "404": {
             "description": "존재하지 않는 그룹"


### PR DESCRIPTION
# 설명
- #191 
- 리더 본인이 자신을 추방할 수 없도록 수정 (403)
![제목 없음](https://github.com/Selody-project/Backend/assets/81506668/0e5b67af-2fa7-4642-9528-dfd37cd56367)
- DELETE `/api/group/:group_id/members/:user_id` : 유저 그룹 강퇴
- update test code
- update swagger

# 테스트
- Integration Test
