### PR TITLE
ISSUE211-fix-api-response-and-add-user-setting

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -206,28 +206,27 @@ describe('Test /api/group endpoints', () => {
       const res = await request(app).post(`/api/group/${groupId}/calendar`).set('Cookie', cookie).send({
         title: 'test-title',
         content: 'test-content',
-        startDateTime: '2023-05-06',
-        endDateTime: '2023-05-07',
+        startDateTime: '2023-05-06T00:00:00.000Z',
+        endDateTime: '2023-05-07T00:00:00.000Z',
         recurrence: 1,
         freq: 'WEEKLY',
         interval: 1,
         byweekday: 'MO',
-        until: '2026-01-05',
+        until: '2026-01-05T00:00:00.000Z',
       });
       const expectedResult = {
-        byweekday: "MO",
-        content: "test-content",
-        endDateTime: "2023-05-07",
-        freq: "WEEKLY",
-        groupId: "1",
-        impossible: null,
-        interval: 1,
-        message: "Successfully create group schedule",
-        possible: null,
+        id: 24,
+        title: 'test-title',
+        content: 'test-content',
+        startDateTime: '2023-05-06T00:00:00.000Z',
+        endDateTime: '2023-05-07T00:00:00.000Z',
         recurrence: 1,
-        startDateTime: "2023-05-06",
-        title: "test-title",
-        until: "2026-01-05",
+        freq: 'WEEKLY',
+        interval: 1,
+        byweekday: 'MO',
+        until: '2026-01-05T00:00:00.000Z',
+        groupId: 1,
+        message: "Successfully create group schedule",
       }
 
       expect(res.status).toEqual(201);
@@ -720,9 +719,19 @@ describe('Test /api/group endpoints', () => {
       const content = 'testContent';
       const data = `{\"title\": \"${title}\", \"content\": \"${content}\"}`;
       const res = await request(app).post(`/api/group/${groupId}/post`).set('Cookie', cookie).field('data', data);
-
+      const expectedResult = {
+        author: 'test-user1',
+        content: 'testContent',
+        image: null,
+        message: 'Successfully created the post.',
+        postDetailId: 11,
+        postId: 11,
+        title: 'testTitle',
+      }
+      delete res.body.updatedAt;
+      delete res.body.createdAt;
       expect(res.status).toEqual(201);
-      expect(res.body).toEqual({ message: 'Successfully created the post.' });
+      expect(res.body).toEqual(expectedResult);
     });
 
     it('Successfully failed to create the post (Group Not Found) ', async () => {
@@ -754,9 +763,21 @@ describe('Test /api/group endpoints', () => {
       const content = 'modified-content';
       const data = `{\"title\": \"${title}\", \"content\": \"${content}\"}`;
       const res = await request(app).put(`/api/group/${groupId}/post/${postId}`).set('Cookie', cookie).field('data', data);
-
+      const expectedResult = {
+        author: 'test-user1',
+        content: 'modified-content',
+        groupId: 1,
+        image: null,
+        message: 'Successfully modified the post.',
+        postDetailId: 1,
+        postId: 1,
+        title: 'modified-title',
+        userId: 1,
+      }
+      delete res.body.updatedAt;
+      delete res.body.createdAt;
       expect(res.status).toEqual(200);
-      expect(res.body).toEqual({ message: 'Successfully modified the post.' });
+      expect(res.body).toEqual(expectedResult);
     });
 
     it('Successfully failed to modified the post (Group Not Found) ', async () => {
@@ -1003,9 +1024,17 @@ describe('Test /api/group endpoints', () => {
       const res = (await request(app).post(`/api/group/${groupId}/post/${postId}/comment`).set('Cookie', cookie).send({
         content,
       }));
-
+      const expectedResult = {
+        commentId: 5,
+        content: 'testComment',
+        depth: 0,
+        message: 'Successfully created the comment.',
+        postId: 1,
+      }
+      delete res.body.updatedAt;
+      delete res.body.createdAt;
       expect(res.status).toEqual(201);
-      expect(res.body).toEqual({ message: 'Successfully created the comment.' });
+      expect(res.body).toEqual(expectedResult);
     });
 
     it('Successfully failed to create the comment (Group Not Found) ', async () => {
@@ -1052,9 +1081,19 @@ describe('Test /api/group endpoints', () => {
       const res = (await request(app).put(`/api/group/${groupId}/post/${postId}/comment/${commentId}`).set('Cookie', cookie).send({
         content,
       }));
+      const expectedResult = {
+        commentId: 1,
+        content: 'testComment',
+        depth: 0,
+        message: 'Successfully created the comment.',
+        postId: 1,
+        userId: 1,
+      }
+      delete res.body.updatedAt;
+      delete res.body.createdAt;
 
       expect(res.status).toEqual(200);
-      expect(res.body).toEqual({ message: 'Successfully modified the comment.' });
+      expect(res.body).toEqual(expectedResult);
     });
 
     it('Successfully failed to modified the comment (Group Not Found) ', async () => {

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -63,7 +63,7 @@ describe('Test /api/user endpoints', () => {
           inviteExp: '2099-01-01T00:00:00.000Z',
           isPublicGroup: 0,
           UserGroup: {
-            groupId: 1, userId: 1, sharePersonalEvent: 1, isPendingMember: 0, accessLevel: 'owner',
+            groupId: 1, userId: 1, shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0, accessLevel: 'owner',
           },
         }, {
           groupId: 2,
@@ -75,7 +75,7 @@ describe('Test /api/user endpoints', () => {
           inviteExp: '2000-01-01T00:00:00.000Z',
           isPublicGroup: 0,
           UserGroup: {
-            groupId: 2, userId: 1, sharePersonalEvent: 1, isPendingMember: 0, accessLevel: 'regular',
+            groupId: 2, userId: 1, shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0, accessLevel: 'regular',
           },
         }],
       };
@@ -503,17 +503,18 @@ describe('Test /api/user endpoints', () => {
 
       const res = await request(app).post('/api/user/calendar').set('Cookie', cookie).send(schedule);
       const expectedResult = {
-        byweekday: null,
-        content: "test-content1",
-        endDateTime: "2023-05-15 00:00:00",
+        id: 25,
+        userId: 1,
+        message: "Successfully create user schedule",    
+        title: 'test-title',
+        content: 'test-content1',
+        startDateTime: '2023-02-03T00:00:00.000Z',
+        endDateTime: '2023-05-15T00:00:00.000Z',
+        recurrence: 0,
         freq: null,
         interval: null,
-        message: "Successfully create user schedule",
-        recurrence: 0,
-        startDateTime: "2023-02-03 00:00:00",
-        title: "test-title",
+        byweekday: null,
         until: null,
-        userId: 1,
       };
 
       expect(res.statusCode).toEqual(201);
@@ -572,44 +573,48 @@ describe('Test /api/user endpoints', () => {
 
   describe('Test DELETE /api/auth/withdrawal', () => {
     it('Successfully deleted a user from user table', async () => {
-      const id = 4;
-      const res = await request(app).delete(`/api/auth/withdrawal/${id}`).set('Cookie', cookie);
+      let res = await request(app).post('/api/auth/login').send({
+        email: 'test-user6@email.com',
+        password: 'super_strong_password',
+      });
+      // eslint-disable-next-line prefer-destructuring
+      const tempCookie = res.headers['set-cookie'][0];
+      res = await request(app).delete(`/api/auth/withdrawal`).set('Cookie', tempCookie);
       expect(res.status).toEqual(204);
     });
 
     it('Successfully failed to delete a user from user table (UserIsLeader Error)', async () => {
-      const id = 1;
-      const res = await request(app).delete(`/api/auth/withdrawal/${id}`).set('Cookie', cookie);
+      const res = await request(app).delete(`/api/auth/withdrawal`).set('Cookie', cookie);
       expect(res.status).toEqual(499);
     });
 
     it('Successfully failed to delete a user from user table (BelongToGroup Error)', async () => {
-      const id = 5;
-      const res = await request(app).delete(`/api/auth/withdrawal/${id}`).set('Cookie', cookie);
+      let res = await request(app).post('/api/auth/login').send({
+        email: 'test-user5@email.com',
+        password: 'super_strong_password',
+      });
+      // eslint-disable-next-line prefer-destructuring
+      const tempCookie = res.headers['set-cookie'][0];
+      res = await request(app).delete(`/api/auth/withdrawal`).set('Cookie', tempCookie);
       expect(res.status).toEqual(403);
     });
   });
 
-  describe('Test PATCH /api/user/updateUserSetup', () => {
-    it('Successfully update sharePersoanlEvent from user table', async () => {
-      const id = 1;
-      const result = {
-        updatedSharePersonalEvent: [
-          {
-            groupId: 1,
-            sharePersonalEvent: 0,
-          },
-          {
-            groupId: 2,
-            sharePersonalEvent: 0,
-          },
-          {
-            groupId: 3,
-            sharePersonalEvent: 1,
-          },
-        ],
-      };
-      const res = await request(app).patch(`/api/user/userSetup/${id}`).set('Cookie', cookie).send(result);
+  describe('Test PATCH /api/user/settings', () => {
+    it('Successfully updated a shareScheduleOption', async () => {
+      const groupId = 1;
+      const res = await request(app).patch(`/api/user/settings/${groupId}`).set('Cookie', cookie).send({
+        shareScheduleOption: 1
+      });
+
+      expect(res.status).toEqual(200);
+    });
+
+    it('Successfully updated a notificationOption', async () => {
+      const groupId = 1;
+      const res = await request(app).patch(`/api/user/settings/${groupId}`).set('Cookie', cookie).send({
+        notificationOption: 1
+      });
 
       expect(res.status).toEqual(200);
     });

--- a/__test__/dbSetup.js
+++ b/__test__/dbSetup.js
@@ -76,6 +76,17 @@ async function setUpUserDB() {
       createdAt: '2023-04-26',
       updatedAt: '2023-04-26',
     },
+    {
+      userId: 6,
+      email: 'test-user6@email.com',
+      nickname: 'test-user6',
+      password: await bcrypt.hash('super_strong_password', 12),
+      provider: 'local',
+      profileImage: 'profileImageLink',
+      createdAt: '2023-04-26',
+      updatedAt: '2023-04-26',
+    },
+    
   ];
 
   await User.create(mockUserData[0]);
@@ -83,6 +94,7 @@ async function setUpUserDB() {
   await User.create(mockUserData[2]);
   await User.create(mockUserData[3]);
   await User.create(mockUserData[4]);
+  await User.create(mockUserData[5]);
 }
 
 async function setUpGroupDB() {
@@ -115,13 +127,13 @@ async function setUpGroupDB() {
   });
   
   const user = await User.findAll();
-  await user[0].addGroup(group1, { through: { accessLevel: 'owner', sharePersonalEvent: 1, isPendingMember: 0 } });
-  await user[0].addGroup(group2, { through: { accessLevel: 'regular', sharePersonalEvent: 1, isPendingMember: 0 } });
-  await user[1].addGroup(group1, { through: { accessLevel: 'admin', sharePersonalEvent: 0, isPendingMember: 0 } });
-  await user[1].addGroup(group2, { through: { accessLevel: 'owner', sharePersonalEvent: 1, isPendingMember: 0 } });
-  await user[2].addGroup(group3, { through: { accessLevel: 'owner', sharePersonalEvent: 1, isPendingMember: 0 } });
-  await user[4].addGroup(group1, { through: { accessLevel: 'viewer', sharePersonalEvent: 1, isPendingMember: 1 } });
-  await user[4].addGroup(group3, { through: { accessLevel: 'admin', sharePersonalEvent: 1, isPendingMember: 0 } });
+  await user[0].addGroup(group1, { through: { accessLevel: 'owner', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0 } });
+  await user[0].addGroup(group2, { through: { accessLevel: 'regular', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0 } });
+  await user[1].addGroup(group1, { through: { accessLevel: 'admin', shareScheduleOption: 0, notificationOption: 1, isPendingMember: 0 } });
+  await user[1].addGroup(group2, { through: { accessLevel: 'owner', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0 } });
+  await user[2].addGroup(group3, { through: { accessLevel: 'owner', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0 } });
+  await user[4].addGroup(group1, { through: { accessLevel: 'viewer', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 1 } });
+  await user[4].addGroup(group3, { through: { accessLevel: 'admin', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0 } });
 }
 
 async function setUpGroupScheduleDB() {

--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -37,7 +37,12 @@ async function postGroup(req, res, next) {
 
     await user.addGroup(group, { through: { accessLevel: 'owner' } });
 
-    return res.status(200).json({ message: 'Successfully create group' });
+    const response = {
+      ...{ message: 'Successfully create group' },
+      ...group.dataValues,
+    };
+
+    return res.status(200).json(response);
   } catch (err) {
     return next(new ApiError());
   }
@@ -158,9 +163,13 @@ async function putGroup(req, res, next) {
     }
 
     const { name, description, leader } = req.body;
-    await group.update({ name, description, leader });
+    const modifiedGroup = await group.update({ name, description, leader });
 
-    return res.status(200).json({ message: 'Successfully modified group info' });
+    const response = {
+      ...{ message: 'Successfully modified group info' },
+      ...modifiedGroup.dataValues,
+    };
+    return res.status(200).json(response);
   } catch (err) {
     return next(new ApiError());
   }

--- a/src/controllers/groupSchedule.js
+++ b/src/controllers/groupSchedule.js
@@ -55,8 +55,8 @@ async function postGroupSchedule(req, res, next) {
       until,
     } = req.body;
 
-    await GroupSchedule.create({
-      groupId,
+    const groupSchedule = await GroupSchedule.create({
+      groupId: group.groupId,
       title,
       content,
       startDateTime,
@@ -69,21 +69,12 @@ async function postGroupSchedule(req, res, next) {
       possible: null,
       impossible: null,
     });
-    return res.status(201).json({
-      message: 'Successfully create group schedule',
-      groupId,
-      title,
-      content,
-      startDateTime,
-      endDateTime,
-      recurrence,
-      freq,
-      interval,
-      byweekday,
-      until,
-      possible: null,
-      impossible: null,
-    });
+    const response = {
+      ...{ message: 'Successfully create group schedule' },
+      ...groupSchedule.dataValues,
+    };
+
+    return res.status(201).json(response);
   } catch (err) {
     return next(new ApiError());
   }
@@ -141,7 +132,7 @@ async function getGroupSchedule(req, res, next) {
     const users = (await UserGroup.findAll({
       where: {
         groupId,
-        sharePersonalEvent: 1,
+        shareScheduleOption: 1,
       },
       attributes: ['userId'],
     })).map((member) => member.userId);
@@ -197,8 +188,13 @@ async function putGroupSchedule(req, res, next) {
       return next(new EditPermissionError());
     }
 
-    await schedule.update(req.body);
-    return res.status(201).json({ message: 'Successfully modify group schedule' });
+    const modifiedSchedule = await schedule.update(req.body);
+    const response = {
+      ...{ message: 'Successfully modify group schedule' },
+      ...modifiedSchedule.dataValues,
+    };
+
+    return res.status(201).json(response);
   } catch (err) {
     return next(new ApiError());
   }
@@ -264,7 +260,7 @@ async function getEventProposal(req, res, next) {
     const groupMembers = (await UserGroup.findAll({
       where: {
         groupId,
-        sharePersonalEvent: 1,
+        shareScheduleOption: 1,
       },
       attributes: ['userId'],
     })).map((member) => member.userId);

--- a/src/controllers/personalSchedule.js
+++ b/src/controllers/personalSchedule.js
@@ -31,12 +31,12 @@ async function postPersonalSchedule(req, res, next) {
       recurrence, freq, interval, byweekday, until,
     } = req.body;
 
-    await PersonalSchedule.create({
+    const schedule = await PersonalSchedule.create({
       userId: user.userId,
       title,
       content,
-      startDateTime: moment.utc(startDateTime).format('YYYY-MM-DD HH:mm:ss'),
-      endDateTime: moment.utc(endDateTime).format('YYYY-MM-DD HH:mm:ss'),
+      startDateTime,
+      endDateTime,
       recurrence,
       freq,
       interval,
@@ -44,19 +44,12 @@ async function postPersonalSchedule(req, res, next) {
       until,
     });
 
-    return res.status(201).json({
-      message: 'Successfully create user schedule',
-      userId: user.userId,
-      title,
-      content,
-      startDateTime: moment.utc(startDateTime).format('YYYY-MM-DD HH:mm:ss'),
-      endDateTime: moment.utc(endDateTime).format('YYYY-MM-DD HH:mm:ss'),
-      recurrence,
-      freq,
-      interval,
-      byweekday,
-      until,
-    });
+    const response = {
+      ...{ message: 'Successfully create user schedule' },
+      ...schedule.dataValues,
+    };
+
+    return res.status(201).json(response);
   } catch (err) {
     return next(new ApiError());
   }
@@ -147,8 +140,14 @@ async function putPersonalSchedule(req, res, next) {
       return next(new EditPermissionError());
     }
 
-    await PersonalSchedule.update(req.body, { where: { id: scheduleId } });
-    return res.status(201).json({ message: 'Successfully Modified.' });
+    const modifiedSchedule = await PersonalSchedule.update(req.body, { where: { id: scheduleId } });
+
+    const response = {
+      ...{ message: 'Successfully Modified.' },
+      ...modifiedSchedule.dataValues,
+    };
+
+    return res.status(201).json(response);
   } catch (err) {
     return next(new ApiError());
   }

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -57,6 +57,10 @@ class Group extends Sequelize.Model {
       foreignKey: 'groupId',
       onDelete: 'cascade',
     });
+    db.Group.hasMany(db.UserGroup, {
+      foreignKey: 'groupId',
+      onDelete: 'cascade',
+    });
   }
 }
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -63,6 +63,10 @@ class User extends Sequelize.Model {
     db.User.hasMany(db.Comment, {
       foreignKey: 'userId',
     });
+    db.User.hasMany(db.UserGroup, {
+      foreignKey: 'userId',
+      onDelete: 'cascade',
+    });
   }
 }
 

--- a/src/models/userGroup.js
+++ b/src/models/userGroup.js
@@ -5,9 +5,22 @@ const Group = require('./group');
 class UserGroup extends Sequelize.Model {
   static initiate(sequelize) {
     UserGroup.init({
-      sharePersonalEvent: {
+      userId: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+      },
+      groupId: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+      },
+      shareScheduleOption: {
         type: Sequelize.TINYINT(1),
-        allowNull: true,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      notificationOption: {
+        type: Sequelize.TINYINT(1),
+        allowaNull: false,
         defaultValue: 1,
       },
       isPendingMember: {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -22,6 +22,6 @@ router.post('/naver', getNaverUserInfo, joinSocialUser, createToken);
 router.post('/google', getGoogleUserInfo, createToken);
 router.get('/token/refresh', renewToken);
 router.get('/token/verify', verifyToken, (req, res) => { res.status(200).end(); });
-router.delete('/withdrawal/:user_id', withdrawal);
+router.delete('/withdrawal', verifyToken, withdrawal);
 
 module.exports = router;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -6,7 +6,7 @@ const { uploadProfileMiddleware } = require('../middleware/s3');
 const {
   getUserGroup,
   patchUserProfile, patchUserPassword,
-  getUserSetup, updateUserSetUp,
+  getUserSetup, patchUserSetUp,
 } = require('../controllers/user');
 
 // Schedule
@@ -30,8 +30,8 @@ router.get('/group', getUserGroup);
 router.delete('/group/:group_id', deleteGroupUser);
 router.patch('/profile', uploadProfileMiddleware, patchUserProfile, createToken);
 router.patch('/profile/password', patchUserPassword);
-router.patch('/userSetup/:user_id', updateUserSetUp);
-router.get('/userSetup', getUserSetup);
+router.get('/settings', getUserSetup);
+router.patch('/settings/:group_id', patchUserSetUp);
 
 // Schedule
 router.get('/calendar', getUserPersonalSchedule);

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -174,19 +174,11 @@
         }
       }
     },
-    "/api/auth/withdrawal/{user_id}": {
+    "/api/auth/withdrawal": {
       "delete": {
         "description": "회원 탈퇴",
-        "summary": "유저 회원 탈퇴",
+        "summary": "회원 탈퇴",
         "tags": ["Auth"],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          }
-        ],
         "responses": {
           "204": {
             "description": "성공"
@@ -1775,6 +1767,91 @@
         }
       }
     },
+    "/api/user/settings": {
+      "get": {
+        "description": "",
+        "summary": "그룹 설정 조회",
+        "tags": ["User"],
+        "responses": {
+          "200": {
+            "description": "성공"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 유저"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/user/settings/{group_id}": {
+      "patch": {
+        "description": "shareScheduleOption과 notificationOption이 있을텐데, 각 토글에 알맞은 key-value값만을 포함하여 변경하면 됩니다.(예시 참고)",
+        "summary": "그룹 설정 변경",
+        "tags": ["User"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "shareScheduleOption": {
+                    "type": "TINYINT(1)"
+                  },
+                  "notificationOption": {
+                    "type": "TINYINT(1)"
+                  }
+                }
+              },
+              "examples": {
+                "shareScheduleOption" : {
+                  "value": {
+                    "shareScheduleOption": 0
+                  },
+                  "description": "일정 공유 토글 on/off"
+                },
+                "notificationOption" : {
+                  "value": {
+                    "notificationOption": 0
+                  },
+                  "description": "알림 토글 on/off"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "성공"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "403": {
+            "description": "수정할 권한이 없음(본인의 그룹이 아님)"
+          },
+          "404": {
+            "description": "존재하지 않는 유저/그룹"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },  
     "/api/user/profile": {
       "patch": {
         "description": "프로필 이미지 변경 시, 이미지 파일을 같이 전달해주세요. 이미지를 제외한 닉네임, 이메일 변경 시에는 send empty value 체크 후에 data만 작성 후, 요청을 보내주시면 됩니다.",
@@ -1864,7 +1941,7 @@
           }
         }
       }
-    },          
+    },  
     "/api/user/calendar": {
       "get": {
         "description": "",
@@ -2406,7 +2483,10 @@
           "userId": {
             "type": "BIGINT"
           },
-          "sharePersonalEvent": {
+          "shareScheduleOption": {
+            "type": "TINYINT(1)"
+          },
+          "notificationOption": {
             "type": "TINYINT(1)"
           },
           "isPendingMember": {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -133,6 +133,11 @@ const groupSearchKeywordSchema = Joi.object({
   ),
 });
 
+const userSettingSchema = Joi.object({
+  shareScheduleOption: Joi.number(),
+  notificationOption: Joi.number(),
+}).or('shareScheduleOption', 'notificationOption');
+
 module.exports = {
   validateLoginSchema: validator(loginSchema),
   validateJoinSchema: validator(joinSchema),
@@ -156,4 +161,5 @@ module.exports = {
   validateGroupJoinInviteCodeSchema: validator(groupJoinInviteCodeSchema),
   validateGroupJoinRequestSchema: validator(groupJoinRequestSchema),
   validateGroupdSearchKeyword: validator(groupSearchKeywordSchema),
+  validateUserSettingSchema: validator(userSettingSchema),
 };


### PR DESCRIPTION
# 설명
- #211 
- 유저 설정 기능 업데이트
- shareScheduleOption : 일정 공유 옵션
- notificationOption: 그룹 알림 옵션
- GET `/api/user/settings` : 유저 설정 조회
![설정 조회](https://github.com/Selody-project/Backend/assets/81506668/9919f60e-7ebb-45d8-834a-92aaa39558b7)
- PATCH `/api/user/settings/:group_id` : 유저 설정 변경(예시 참고)
![설정 화면](https://github.com/Selody-project/Backend/assets/81506668/45906059-0699-418e-8a7a-4f8db340ec8f)
- 회원 탈퇴 시, params로 user_id를 넘겨받았으나, 해당 부분 삭제
- DELETE `/api/auth/withdrawal`를 호출하면 회원탈퇴 진행
- update test code
- update swagger


# 테스트
- Integration Test
