### PR TITLE
ISSUE214-fix-pagination

### DIFF
--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -622,12 +622,10 @@ describe('Test /api/user endpoints', () => {
     });
   });
 
-  describe('Test GET /api/user/feed', () => {
+  describe('Test GET /api/user/feed/:last_record_id', () => {
     it('Successfully retrieved feed', async () => {
-      const page = 1;
-      const res = await request(app).get('/api/user/feed').set('Cookie', cookie).query({
-        page,
-      });
+      const lastRecordId = 0;
+      const res = await request(app).get(`/api/user/feed/${lastRecordId}`).set('Cookie', cookie);
       const expectedResult = [
         {
           postId: 1,
@@ -719,16 +717,6 @@ describe('Test /api/user endpoints', () => {
           author: 'test-user1',
           content: 'test-content9'
         },
-        {
-          postId: 10,
-          groupId: 1,
-          isMine: true,
-          isLiked: false,
-          likesCount: 0,
-          title: 'test-title10',
-          author: 'test-user1',
-          content: 'test-content10'
-        }
       ];
 
       const result = res.body.feed.map((post) => ({
@@ -746,10 +734,8 @@ describe('Test /api/user endpoints', () => {
     });
 
     it('Successfully failed to retrieve feed (DataFormat Error)', async () => {
-      const page = 'abc';
-      const res = await request(app).get('/api/user/feed').set('Cookie', cookie).query({
-        page,
-      });
+      const lastRecordId = 'abc';
+      const res = await request(app).get(`/api/user/feed/${lastRecordId}`).set('Cookie', cookie);
       expect(res.status).toEqual(400);
     });
   });

--- a/__test__/dbSetup.js
+++ b/__test__/dbSetup.js
@@ -381,34 +381,34 @@ async function setUpGroupPostDB() {
 
   await PostDetail.bulkCreate([
     {
-      postDetailId: 1, postId: 1, content: 'test-content1',
+      postDetailId: 1, postId: 1, content: 'test-content1', image: 'postImage'
     },
     {
-      postDetailId: 2, postId: 2, content: 'test-content2',
+      postDetailId: 2, postId: 2, content: 'test-content2', image: 'postImage'
     },
     {
-      postDetailId: 3, postId: 3, content: 'test-content3',
+      postDetailId: 3, postId: 3, content: 'test-content3', image: 'postImage'
     },
     {
-      postDetailId: 4, postId: 4, content: 'test-content4',
+      postDetailId: 4, postId: 4, content: 'test-content4', image: 'postImage'
     },
     {
-      postDetailId: 5, postId: 5, content: 'test-content5',
+      postDetailId: 5, postId: 5, content: 'test-content5', image: 'postImage'
     },
     {
-      postDetailId: 6, postId: 6, content: 'test-content6',
+      postDetailId: 6, postId: 6, content: 'test-content6', image: 'postImage'
     },
     {
-      postDetailId: 7, postId: 7, content: 'test-content7',
+      postDetailId: 7, postId: 7, content: 'test-content7', image: 'postImage'
     },
     {
-      postDetailId: 8, postId: 8, content: 'test-content8',
+      postDetailId: 8, postId: 8, content: 'test-content8', image: 'postImage'
     },
     {
-      postDetailId: 9, postId: 9, content: 'test-content9',
+      postDetailId: 9, postId: 9, content: 'test-content9', image: 'postImage'
     },
     {
-      postDetailId: 10, postId: 10, content: 'test-content10',
+      postDetailId: 10, postId: 10, content: 'test-content10', image: 'postImage'
     },
   ]);
 

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -33,7 +33,7 @@ const router = express.Router();
 
 // Group
 router.post('/', uploadGroupMiddleware, postGroup);
-router.get('/', getGroupList);
+router.get('/list/:last_record_id', getGroupList);
 router.get('/search', searchGroup);
 router.get('/:group_id/info', getGroupInfo);
 router.get('/:group_id', getGroupDetail);
@@ -59,7 +59,7 @@ router.get('/:group_id/proposal', getEventProposal);
 
 // Feed
 router.post('/:group_id/post', uploadPostMiddleware, postGroupPost);
-router.get('/:group_id/post', getGroupPosts);
+router.get('/:group_id/feed/:last_record_id', getGroupPosts);
 router.get('/:group_id/post/:post_id', getSinglePost);
 router.put('/:group_id/post/:post_id', uploadPostMiddleware, putGroupPost);
 router.delete('/:group_id/post/:post_id', deleteGroupPost);

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -41,6 +41,6 @@ router.put('/calendar/:schedule_id', putPersonalSchedule);
 router.delete('/calendar/:schedule_id', deletePersonalSchedule);
 
 // Feed
-router.get('/feed', getUserFeed);
+router.get('/feed/:last_record_id', getUserFeed);
 
 module.exports = router;

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -276,15 +276,17 @@
             "description": "서버 에러"
           }
         }
-      },
+      }
+    },
+    "/api/group/list/{last_record_id}": {
       "get": {
-        "description": "한 페이지(9개의 group 정보) 단위로 그룹 리스트를 조회합니다. groupId, 그룹명, 소개, 멤버 수를 보여줍니다.",
+        "description": "9개 단위로 그룹 리스트를 조회합니다. groupId, 그룹명, 소개, 멤버 수를 보여줍니다.",
         "summary": "그룹 리스트 조회",
         "tags": ["Group"],
         "parameters": [
           {
-            "name": "page",
-            "in": "query",
+            "name": "last_record_id",
+            "in": "path",
             "type": "integer"
           }
         ],
@@ -1193,10 +1195,10 @@
         }
       }
     },
-    "/api/group/{group_id}/post": {
+    "/api/group/{group_id}/feed/{last_record_id}": {
       "get": {
-        "description": "페이지네이션",
-        "summary": "그룹 포스트 페이지 조회(7개 단위)",
+        "description": "현재 마지막 레코드의 id 값을 last_record_id에 넣어 요청하면, 해당 레코드 이전에 생성된 9개의 시간순 레코드를 얻어옵니다. 첫 호출시에는 0을 넣어주세요.",
+        "summary": "그룹 피드 조회(9개 단위)",
         "tags": ["Feed"],
         "parameters": [
           {
@@ -1206,8 +1208,8 @@
             "type": "integer"
           },
           {
-            "name": "page",
-            "in": "query",
+            "name": "last_record_id",
+            "in": "path",
             "required": true,
             "type": "integer"
           }
@@ -1226,7 +1228,9 @@
             "description": "서버 에러"
           }
         }
-      },
+      }
+    },
+    "/api/group/{group_id}/post": {
       "post": {
         "description": "",
         "summary": "그룹 포스트 작성",
@@ -1729,15 +1733,15 @@
         }
       }
     },
-    "/api/user/feed": {
+    "/api/user/feed/{last_record_id}": {
       "get": {
-        "description": "가입된 모든 그룹의 피드를 시간순으로 가져옵니다 ( 12개 단위 )",
+        "description": "가입된 모든 그룹의 피드를 시간순으로 가져옵니다 ( 9개 단위 )",
         "summary": "최신 피드 조회",
         "tags": ["Feed"],
         "parameters": [
           {
-            "name": "page",
-            "in": "query",
+            "name": "last_record_id",
+            "in": "path",
             "required": true,
             "type": "integer"
           }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -104,7 +104,12 @@ const postIdSchema = Joi.object({
 });
 
 const pageSchema = Joi.object({
-  page: Joi.number().min(0).required(),
+  group_id: Joi.number().min(0).required(),
+  last_record_id: Joi.number().min(0).required(),
+});
+
+const lastRecordIdSchema = Joi.object({
+  last_record_id: Joi.number().min(0).required(),
 });
 
 const commentSchema = Joi.object({
@@ -154,6 +159,7 @@ module.exports = {
   validatePostSchema: validator(postSchema),
   validatePostIdSchema: validator(postIdSchema),
   validatePageSchema: validator(pageSchema),
+  validateLastRecordIdSchema: validator(lastRecordIdSchema),
   validateCommentSchema: validator(commentSchema),
   validateCommentIdSchema: validator(commentIdSchema),
   validateGroupJoinInviteCodeSchema: validator(groupJoinInviteCodeSchema),


### PR DESCRIPTION
# 설명

- #214 
- api 앤드포인트에 약간의 변화가 있었습니다.
- GET `/api/group/list/:last_record_id` : 그룹 리스트 조회(그룹 추천에서)
- GET `/api/group/:group_id/feed/:last_record_id` : 그룹 피드 최신 순 조회
- GET `/api/user/feed/:last_record_id` : 유저 최신 피드 조회
- 위의 api를 처음 호출 할 시에는 last_record_id 값을 0으로 주시면 됩니다.
- update test code
- update swagger

# 테스트
- Integration Test
