### PR TITLE
ISSUE236-fix-put-user-profile

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -387,6 +387,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title11',
               startDateTime: '2020-01-01T12:00:00.000Z',
+              endDateTime: '2020-01-01T13:00:00.000Z',
               until: '2023-04-05T14:00:00.000Z',
             },
             {
@@ -403,6 +404,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title12',
               startDateTime: '2020-01-15T12:00:00.000Z',
+              endDateTime: '2020-01-15T13:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -422,6 +424,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title13',
               startDateTime: '2020-01-15T12:00:00.000Z',
+              endDateTime: '2020-01-15T13:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -438,6 +441,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title14',
               startDateTime: '2020-04-15T12:00:00.000Z',
+              endDateTime: '2020-04-15T13:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -461,6 +465,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title15',
               startDateTime: '2020-01-13T12:00:00.000Z',
+              endDateTime: '2020-01-13T13:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -480,6 +485,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title16',
               startDateTime: '2020-03-15T12:00:00.000Z',
+              endDateTime: '2020-04-01T00:00:00.000Z',
               until: '2023-03-20T00:00:00.000Z',
             },
             {
@@ -502,6 +508,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title17',
               startDateTime: '2020-03-15T12:00:00.000Z',
+              endDateTime: '2020-04-01T00:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -518,6 +525,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title18',
               startDateTime: '2020-03-15T12:00:00.000Z',
+              endDateTime: '2020-04-01T00:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -534,6 +542,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title19',
               startDateTime: '2020-01-15T12:00:00.000Z',
+              endDateTime: '2020-04-01T00:00:00.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
             {
@@ -550,6 +559,7 @@ describe('Test /api/group endpoints', () => {
               ],
               title: 'test-title21',
               startDateTime: '2020-04-30T23:59:59.000Z',
+              endDateTime: '2020-05-01T23:59:59.000Z',
               until: '2025-01-01T00:00:00.000Z',
             },
           ],

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -90,7 +90,8 @@ describe('Test /api/user endpoints', () => {
     it('Successfully modified user profile ', async () => {
       const newNickname = 'newNickname';
       const newEmail = 'newEmail@email.com';
-      const data = `{\"nickname\": \"${newNickname}\", \"email\": \"${newEmail}\"}`;
+      const newIntroduction = 'newIntroduction';
+      const data = `{\"nickname\": \"${newNickname}\", \"email\": \"${newEmail}\", \"introduction\": \"${newIntroduction}\"}`;
       const res = await request(app).patch('/api/user/profile').set('Cookie', cookie).field('data', data);
       const expectedResult = {
         email: newEmail,
@@ -99,6 +100,7 @@ describe('Test /api/user endpoints', () => {
         profileImage: 'profileImageLink',
         provider: 'local',
         snsId: null,
+        introduction: newIntroduction,
         userId: 1,
       };
       expect(res.status).toEqual(200);
@@ -261,6 +263,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title11',
             startDateTime: '2020-01-01T12:00:00.000Z',
+            endDateTime: '2020-01-01T13:00:00.000Z',
             until: '2023-04-05T14:00:00.000Z',
           },
           {
@@ -277,6 +280,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title12',
             startDateTime: '2020-01-15T12:00:00.000Z',
+            endDateTime: '2020-01-15T13:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -296,6 +300,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title13',
             startDateTime: '2020-01-15T12:00:00.000Z',
+            endDateTime: '2020-01-15T13:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -312,6 +317,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title14',
             startDateTime: '2020-04-15T12:00:00.000Z',
+            endDateTime: '2020-04-15T13:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -335,6 +341,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title15',
             startDateTime: '2020-01-13T12:00:00.000Z',
+            endDateTime: '2020-01-13T13:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -354,6 +361,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title16',
             startDateTime: '2020-03-15T12:00:00.000Z',
+            endDateTime: '2020-04-01T00:00:00.000Z',
             until: '2023-03-20T00:00:00.000Z',
           },
           {
@@ -376,6 +384,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title17',
             startDateTime: '2020-03-15T12:00:00.000Z',
+            endDateTime: '2020-04-01T00:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -392,6 +401,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title18',
             startDateTime: '2020-03-15T12:00:00.000Z',
+            endDateTime: '2020-04-01T00:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -408,6 +418,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title19',
             startDateTime: '2020-01-15T12:00:00.000Z',
+            endDateTime: '2020-04-01T00:00:00.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
           {
@@ -424,6 +435,7 @@ describe('Test /api/user endpoints', () => {
             ],
             title: 'test-title21',
             startDateTime: '2020-04-30T23:59:59.000Z',
+            endDateTime: '2020-05-01T23:59:59.000Z',
             until: '2025-01-01T00:00:00.000Z',
           },
         ],

--- a/src/controllers/groupSchedule.js
+++ b/src/controllers/groupSchedule.js
@@ -250,7 +250,8 @@ async function putGroupSchedule(req, res, next) {
       return next(new EditPermissionError());
     }
 
-    const modifiedSchedule = await schedule.update(req.body);
+    await schedule.update(req.body);
+    const modifiedSchedule = await GroupSchedule.findByPk(scheduleId);
     const response = {
       ...{ message: '성공적으로 수정되었습니다.' },
       ...modifiedSchedule.dataValues,

--- a/src/controllers/personalSchedule.js
+++ b/src/controllers/personalSchedule.js
@@ -187,8 +187,8 @@ async function putPersonalSchedule(req, res, next) {
       return next(new EditPermissionError());
     }
 
-    const modifiedSchedule = await PersonalSchedule.update(req.body, { where: { id: scheduleId } });
-
+    await PersonalSchedule.update(req.body, { where: { id: scheduleId } });
+    const modifiedSchedule = await PersonalSchedule.findByPk(scheduleId);
     const response = {
       ...{ message: '성공적으로 수정되었습니다.' },
       ...modifiedSchedule.dataValues,

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -46,7 +46,7 @@ async function patchUserProfile(req, res, next) {
       throw (new DataFormatError());
     }
 
-    const { nickname, email } = req.body;
+    const { nickname, email, introduction } = req.body;
     const { user } = req;
 
     const nicknameDuplicate = await User.findAll({
@@ -66,10 +66,12 @@ async function patchUserProfile(req, res, next) {
     const previousProfileImage = [user.profileImage];
     if (req.fileUrl !== null) {
       const fileUrl = req.fileUrl.join(', ');
-      await user.update({ nickname, email, profileImage: fileUrl });
+      await user.update({
+        nickname, email, introduction, profileImage: fileUrl,
+      });
       await deleteBucketImage(previousProfileImage);
     } else {
-      await user.update({ nickname, email });
+      await user.update({ nickname, email, introduction });
     }
     req.user = user;
     return next();

--- a/src/middleware/token.js
+++ b/src/middleware/token.js
@@ -48,6 +48,7 @@ async function createToken(req, res, next) {
       provider: user.provider,
       snsId: user.snsId,
       profileImage: user.profileImage,
+      introduction: user.introduction,
     });
   } catch (error) {
     return next(new ApiError());

--- a/src/models/groupSchedule.js
+++ b/src/models/groupSchedule.js
@@ -181,9 +181,9 @@ class GroupSchedule extends Sequelize.Model {
               interval: schedule.interval,
               byweekday: schedule.byweekday,
               startDateTime: schedule.startDateTime,
+              endDateTime: schedule.endDateTime,
               until: schedule.until,
               isGroup: schedule.isGroup,
-              recurrenceDateList: possibleDateList,
             });
           } else {
             recurrenceSchedule.push({
@@ -196,6 +196,7 @@ class GroupSchedule extends Sequelize.Model {
               interval: schedule.interval,
               byweekday: schedule.byweekday,
               startDateTime: schedule.startDateTime,
+              endDateTime: schedule.endDateTime,
               until: schedule.until,
               isGroup: schedule.isGroup,
               recurrenceDateList: possibleDateList,

--- a/src/models/personalSchedule.js
+++ b/src/models/personalSchedule.js
@@ -136,6 +136,7 @@ class PersonalSchedule extends Sequelize.Model {
         },
         type: Sequelize.QueryTypes.SELECT,
       });
+
       const recurrenceSchedule = [];
       recurrenceScheduleList.forEach((schedule) => {
         const byweekday = getRRuleByWeekDay(schedule.byweekday);
@@ -181,9 +182,9 @@ class PersonalSchedule extends Sequelize.Model {
               interval: schedule.interval,
               byweekday: schedule.byweekday,
               startDateTime: schedule.startDateTime,
+              endDateTime: schedule.endDateTime,
               until: schedule.until,
               isGroup: schedule.isGroup,
-              recurrenceDateList: possibleDateList,
             });
           } else {
             recurrenceSchedule.push({
@@ -196,6 +197,7 @@ class PersonalSchedule extends Sequelize.Model {
               interval: schedule.interval,
               byweekday: schedule.byweekday,
               startDateTime: schedule.startDateTime,
+              endDateTime: schedule.endDateTime,
               until: schedule.until,
               isGroup: schedule.isGroup,
               recurrenceDateList: possibleDateList,
@@ -206,7 +208,9 @@ class PersonalSchedule extends Sequelize.Model {
       if (earliestDate === Number.MAX_SAFE_INTEGER) {
         earliestDate = null;
       }
-      return { earliestDate, nonRecurrenceSchedule, recurrenceSchedule };
+      return {
+        earliestDate, nonRecurrenceSchedule, recurrenceSchedule, recurrenceScheduleList,
+      };
     } catch (err) {
       throw new ApiError();
     }

--- a/src/models/personalSchedule.js
+++ b/src/models/personalSchedule.js
@@ -208,9 +208,7 @@ class PersonalSchedule extends Sequelize.Model {
       if (earliestDate === Number.MAX_SAFE_INTEGER) {
         earliestDate = null;
       }
-      return {
-        earliestDate, nonRecurrenceSchedule, recurrenceSchedule, recurrenceScheduleList,
-      };
+      return { earliestDate, nonRecurrenceSchedule, recurrenceSchedule };
     } catch (err) {
       throw new ApiError();
     }

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -1925,7 +1925,7 @@
                   },
                   "data": {
                     "type": "string",
-                    "example": "{\"email\": \"modified@email.com\", \"nickname\": \"modified-nick\"}"
+                    "example": "{\"email\": \"modified@email.com\", \"nickname\": \"modified-nick\", \"introduction\": \"modified-introduction\"}"
                   }
                 }
               }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -13,6 +13,7 @@ const joinSchema = Joi.object({
 const profileSchema = Joi.object({
   email: Joi.string().email().min(1).max(40).required(),
   nickname: Joi.string().min(1).max(15).required(),
+  introduction: Joi.string().max(50).required(),
 });
 
 const passwordSchema = Joi.object({


### PR DESCRIPTION
# 설명

- #236 
  - 프로필 정보 수정에서 introduction을 추가
  - email, nickname, introduction을 모두 보내주어야 함.

- #239 
  - 요약된 일정 조회 시, endDatetime을 같이 리턴하도록 수정
  - 반복일정은 recurrenceDateList를 제외하고 리턴하도록 수정
  - 기본 일정 조회 시,
![제목 없음2](https://github.com/Selody-project/Backend/assets/81506668/dd05e560-09bc-4a79-a02e-ae6885be1fbb)
  - 요약된 일정 조회 시,
![제목 없음1](https://github.com/Selody-project/Backend/assets/81506668/faf0bc93-5490-4b4a-aa85-b62e1c90607f)

- update test code
- update swagger


# 테스트
- Integration Test
