### PR TITLE
ISSUE257-fix-byweekday

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -231,7 +231,7 @@ describe('Test /api/group endpoints', () => {
           endRecur: '2026-01-05T00:00:00.000Z',
           isGroup: 1
         },
-        todaySchedule: [
+        todaySchedules: [
           {
             id: 24,
             groupId: 1,
@@ -393,7 +393,7 @@ describe('Test /api/group endpoints', () => {
           endRecur: '2026-01-05T00:00:00.000Z',
           isGroup: 1
         },
-        todaySchedule: [
+        todaySchedules: [
           {
             id: 1,
             groupId: 1,
@@ -779,7 +779,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 1,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -794,7 +794,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 1,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -809,7 +809,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 1,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -824,7 +824,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 1,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -854,7 +854,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -869,7 +869,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -884,7 +884,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -899,7 +899,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -914,7 +914,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -929,7 +929,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -944,7 +944,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -959,7 +959,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 1,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1034,7 +1034,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1049,7 +1049,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1064,7 +1064,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1079,7 +1079,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1094,7 +1094,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1109,7 +1109,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -1124,7 +1124,7 @@ describe('Test /api/group endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 1,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -354,7 +354,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 0,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -369,7 +369,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 0,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -384,7 +384,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 0,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -399,7 +399,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["WE"],
+            byweekday: [3],
             isGroup: 0,
             startRecur: '2020-01-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -429,7 +429,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -444,7 +444,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -459,7 +459,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -474,7 +474,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -489,7 +489,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -504,7 +504,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -519,7 +519,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -534,7 +534,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["MO", "TU"],
+            byweekday: [1, 2],
             isGroup: 0,
             startRecur: '2020-01-13T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -609,7 +609,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -624,7 +624,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -639,7 +639,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -654,7 +654,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -669,7 +669,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -684,7 +684,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -699,7 +699,7 @@ describe('Test /api/user endpoints', () => {
             recurrence: 1,
             freq: 'WEEKLY',
             interval: 1,
-            byweekday: ["SU"],
+            byweekday: [0],
             isGroup: 0,
             startRecur: '2020-03-15T12:00:00.000Z',
             endRecur: '2025-01-01T00:00:00.000Z'
@@ -870,7 +870,7 @@ describe('Test /api/user endpoints', () => {
           endRecur: '2026-01-05T00:00:00.000Z',
           isGroup: 0
         },
-        todaySchedule: [
+        todaySchedules: [
           {
             id: 1,
             userId: 1,
@@ -997,7 +997,7 @@ describe('Test /api/user endpoints', () => {
           until: null,
           isGroup: 0
         },
-        todaySchedule: [
+        todaySchedules: [
           {
             id: 25,
             userId: 1,
@@ -1064,7 +1064,7 @@ describe('Test /api/user endpoints', () => {
           endRecur: '2026-01-05T00:00:00.000Z',
           isGroup: 0
         },
-        todaySchedule: [
+        todaySchedules: [
           {
             id: 26,
             userId: 1,

--- a/__test__/dbSetup.js
+++ b/__test__/dbSetup.js
@@ -221,19 +221,19 @@ async function setUpGroupScheduleDB() {
       id: 12, groupId: 1, title: 'test-title12', content: 'test-content12', startDateTime: '2020-01-15T12:00:00.000Z', endDateTime: '2020-01-15T13:00:00.000Z', recurrence: 1, freq: 'MONTHLY', interval: 1, byweekday: null, until: '2025-01-01',
     },
     {
-      id: 13, groupId: 1, title: 'test-title13', content: 'test-content13', startDateTime: '2020-01-15T12:00:00.000Z', endDateTime: '2020-01-15T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: ["WE"], until: '2025-01-01',
+      id: 13, groupId: 1, title: 'test-title13', content: 'test-content13', startDateTime: '2020-01-15T12:00:00.000Z', endDateTime: '2020-01-15T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: [3], until: '2025-01-01',
     },
     {
       id: 14, groupId: 1, title: 'test-title14', content: 'test-content14', startDateTime: '2020-04-15T12:00:00.000Z', endDateTime: '2020-04-15T13:00:00.000Z', recurrence: 1, freq: 'YEARLY', interval: 1, byweekday: null, until: '2025-01-01',
     },
     {
-      id: 15, groupId: 1, title: 'test-title15', content: 'test-content15', startDateTime: '2020-01-13T12:00:00.000Z', endDateTime: '2020-01-13T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: ["MO", "TU"], until: '2025-01-01',
+      id: 15, groupId: 1, title: 'test-title15', content: 'test-content15', startDateTime: '2020-01-13T12:00:00.000Z', endDateTime: '2020-01-13T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: [1, 2], until: '2025-01-01',
     },
     {
       id: 16, groupId: 1, title: 'test-title16', content: 'test-content16', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'DAILY', interval: 1, byweekday: null, until: '2023-03-20',
     },
     {
-      id: 17, groupId: 1, title: 'test-title17', content: 'test-content17', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: ["SU"], until: '2025-01-01',
+      id: 17, groupId: 1, title: 'test-title17', content: 'test-content17', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: [0], until: '2025-01-01',
     },
     {
       id: 18, groupId: 1, title: 'test-title18', content: 'test-content18', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'MONTHLY', interval: 1, byweekday: null, until: '2025-01-01',
@@ -295,19 +295,19 @@ async function setUpPersonalScheduleDB() {
       id: 12, userId: 1, title: 'test-title12', content: 'test-content12', startDateTime: '2020-01-15T12:00:00.000Z', endDateTime: '2020-01-15T13:00:00.000Z', recurrence: 1, freq: 'MONTHLY', interval: 1, byweekday: null, until: '2025-01-01',
     },
     {
-      id: 13, userId: 1, title: 'test-title13', content: 'test-content13', startDateTime: '2020-01-15T12:00:00.000Z', endDateTime: '2020-01-15T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: ["WE"], until: '2025-01-01',
+      id: 13, userId: 1, title: 'test-title13', content: 'test-content13', startDateTime: '2020-01-15T12:00:00.000Z', endDateTime: '2020-01-15T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: [3], until: '2025-01-01',
     },
     {
       id: 14, userId: 1, title: 'test-title14', content: 'test-content14', startDateTime: '2020-04-15T12:00:00.000Z', endDateTime: '2020-04-15T13:00:00.000Z', recurrence: 1, freq: 'YEARLY', interval: 1, byweekday: null, until: '2025-01-01',
     },
     {
-      id: 15, userId: 1, title: 'test-title15', content: 'test-content15', startDateTime: '2020-01-13T12:00:00.000Z', endDateTime: '2020-01-13T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: ["MO", "TU"], until: '2025-01-01',
+      id: 15, userId: 1, title: 'test-title15', content: 'test-content15', startDateTime: '2020-01-13T12:00:00.000Z', endDateTime: '2020-01-13T13:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: [1, 2], until: '2025-01-01',
     },
     {
       id: 16, userId: 1, title: 'test-title16', content: 'test-content16', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'DAILY', interval: 1, byweekday: null, until: '2023-03-20',
     },
     {
-      id: 17, userId: 1, title: 'test-title17', content: 'test-content17', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: ["SU"], until: '2025-01-01',
+      id: 17, userId: 1, title: 'test-title17', content: 'test-content17', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'WEEKLY', interval: 1, byweekday: [0], until: '2025-01-01',
     },
     {
       id: 18, userId: 1, title: 'test-title18', content: 'test-content18', startDateTime: '2020-03-15T12:00:00.000Z', endDateTime: '2020-04-01T00:00:00.000Z', recurrence: 1, freq: 'MONTHLY', interval: 1, byweekday: null, until: '2025-01-01',

--- a/src/utils/rrule.js
+++ b/src/utils/rrule.js
@@ -20,13 +20,13 @@ function getRRuleByWeekDay(byweekday) {
   }
   const arr = byweekday;
   const RRuleWeekDay = {
-    MO: RRule.MO,
-    TU: RRule.TU,
-    WE: RRule.WE,
-    TH: RRule.TH,
-    FR: RRule.FR,
-    SA: RRule.SA,
-    SU: RRule.SU,
+    0: RRule.SU,
+    1: RRule.MO,
+    2: RRule.TU,
+    3: RRule.WE,
+    4: RRule.TH,
+    5: RRule.FR,
+    6: RRule.SA,
   };
 
   if (arr[0] === '') {
@@ -51,7 +51,7 @@ async function getScheduleResponse(requestStartDateTime, requestEndDateTime, sch
   }
   const response = {
     scheduleSummary: {},
-    todaySchedule: [],
+    todaySchedules: [],
     schedulesForTheWeek: [],
   };
   // 일반 일정인 경우
@@ -67,7 +67,7 @@ async function getScheduleResponse(requestStartDateTime, requestEndDateTime, sch
 
       // 오늘 일정
       if (startDateTime < requestEnd) {
-        response.todaySchedule.push({ ...schedule });
+        response.todaySchedules.push({ ...schedule });
       }
     }
   } else { // 반복 일정인 경우
@@ -96,13 +96,13 @@ async function getScheduleResponse(requestStartDateTime, requestEndDateTime, sch
       new Date(requestStart.getTime() - scheduleLength),
       new Date(sixDaysLater.getTime() + 1),
     );
+    schedule.startRecur = schedule.startDateTime;
+    schedule.endRecur = schedule.until;
+    delete schedule.until;
+    response.scheduleSummary = { ...schedule };
+    delete response.scheduleSummary.title;
+    delete response.scheduleSummary.content;
     if (scheduleStartTimeList.length !== 0) {
-      schedule.startRecur = schedule.startDateTime;
-      schedule.endRecur = schedule.until;
-      delete schedule.until;
-      response.scheduleSummary = { ...schedule };
-      delete response.scheduleSummary.title;
-      delete response.scheduleSummary.content;
       scheduleStartTimeList.forEach((scheduleStartTime) => {
         const scheduleEndTime = new Date(scheduleStartTime.getTime() + scheduleLength);
         if (scheduleEndTime >= requestStart) {
@@ -111,7 +111,7 @@ async function getScheduleResponse(requestStartDateTime, requestEndDateTime, sch
 
           // 오늘 일정
           if (scheduleStartTime < requestEnd) {
-            response.todaySchedule.push({ ...schedule });
+            response.todaySchedules.push({ ...schedule });
           }
 
           // 일주일 이내 일정

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -78,7 +78,7 @@ const scheduleSchema = Joi.object({
   }),
   byweekday: Joi.when('freq', {
     is: 'WEEKLY',
-    then: Joi.array().items(Joi.string().min(0)).required(),
+    then: Joi.array().items(Joi.number()).required(),
     otherwise: Joi.valid(null).required(),
   }),
   until: Joi.when('recurrence', {


### PR DESCRIPTION
# 설명

- #257 
  - 기존에는 "MO", "TU", "WE" .. 등의 방식으로 저장했었으나, 문자열 대신 integer를 사용하도록 함.
  - [ 1, 3, 5 ] 이런식으로 저장하게 됨.

# 테스트
- Integration Test
