### PR TITLE
ISSUE176-schedule-proposal-vote

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -50,8 +50,8 @@ describe('Test /api/group endpoints', () => {
     await tearDownLikeDB();
     await tearDownPersonalScheduleDB();
     await tearDownGroupScheduleDB();
-    //await tearDownVoteResultDB();
-    //await tearDownVoteDB();
+    await tearDownVoteResultDB();
+    await tearDownVoteDB();
     await tearDownGroupPostDB();
     await tearDownGroupDB();
   });
@@ -137,6 +137,7 @@ describe('Test /api/group endpoints', () => {
             member: 2,
             name: 'test-group1',
             image: 'groupImageLink',
+            feedCount: 8,
           },
           leaderInfo: {
             nickname: 'test-user1',

--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -120,39 +120,6 @@ describe('Test /api/group endpoints', () => {
     });
   });
 
-  describe('Test GET /api/group/:group_id/info', () => {
-    it('Successfully get a group info', async () => {
-      const groupId = 1;
-      const res = await request(app).get(`/api/group/${groupId}/info`).set('Cookie', cookie);
-      const expectedGroups = {
-        accessLevel: 'owner',
-        information: {
-          groupId: 1,
-          name: 'test-group1',
-          description: 'test-description1',
-          member: 2,
-          feed: 8,
-        },
-      };
-
-      expect(res.status).toEqual(200);
-      expect(res.body).toEqual(expectedGroups);
-    });
-
-    it('Successfully failed to get an group info (Group Not Found)', async () => {
-      const groupId = 10000;
-      const res = (await request(app).get(`/api/group/${groupId}/info`).set('Cookie', cookie));
-      expect(res.status).toEqual(404);
-      expect(res.body).toEqual({ error: '그룹을 찾을 수 없습니다.' });
-    });
-
-    it('Successfully fail to get an group info (DataFormat Error)', async () => {
-      const groupId = 'abc';
-      const res = await request(app).get(`/api/group/${groupId}/info`).set('Cookie', cookie);
-      expect(res.status).toEqual(400);
-    });
-  });
-
   describe('Test GET /api/group/:group_id', () => {
     it('Successfully get a group detail', async () => {
       const id = 1;

--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -202,304 +202,6 @@ describe('Test /api/group endpoints', () => {
     });
   });
 
-  describe('Test POST /api/group/:group_id/calendar', () => {
-    it('Group schedule creation successful ', async () => {
-      const groupId = 1;
-      const res = await request(app).post(`/api/group/${groupId}/calendar`).set('Cookie', cookie).send({
-        requestStartDateTime: '2023-05-05T12:00:00.000Z',
-        requestEndDateTime: '2023-05-06T12:00:00.000Z',
-        title: 'test-title',
-        content: 'test-content',
-        startDateTime: '2023-05-06T00:00:00.000Z',
-        endDateTime: '2023-05-07T00:00:00.000Z',
-        recurrence: 1,
-        freq: 'DAILY',
-        interval: 1,
-        byweekday: null,
-        until: '2026-01-05T00:00:00.000Z'
-      });
-      const expectedResult = {
-        scheduleSummary: {
-          id: 24,
-          groupId: 1,
-          startDateTime: '2023-05-06T00:00:00.000Z',
-          endDateTime: '2023-05-07T00:00:00.000Z',
-          recurrence: 1,
-          freq: 'DAILY',
-          interval: 1,
-          byweekday: null,
-          startRecur: '2023-05-06T00:00:00.000Z',
-          endRecur: '2026-01-05T00:00:00.000Z',
-          isGroup: 1
-        },
-        todaySchedules: [
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-06T00:00:00.000Z',
-            endDateTime: '2023-05-07T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          }
-        ],
-        schedulesForTheWeek: [
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-07T00:00:00.000Z',
-            endDateTime: '2023-05-08T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-08T00:00:00.000Z',
-            endDateTime: '2023-05-09T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-09T00:00:00.000Z',
-            endDateTime: '2023-05-10T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-10T00:00:00.000Z',
-            endDateTime: '2023-05-11T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-11T00:00:00.000Z',
-            endDateTime: '2023-05-12T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 24,
-            groupId: 1,
-            title: 'test-title',
-            content: 'test-content',
-            startDateTime: '2023-05-12T00:00:00.000Z',
-            endDateTime: '2023-05-13T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          }
-        ]
-      };
-      expect(res.status).toEqual(201);
-      expect(res.body).toEqual(expectedResult);
-    });
-  });
-
-  describe('Test PUT /api/group/:group_id/calendar/:schedule_id', () => {
-    it('Group Schedule Modification Successful ', async () => {
-      const groupId = 1;
-      const scheduleId = 1;
-      const res = await request(app).put(`/api/group/${groupId}/calendar/${scheduleId}`).set('Cookie', cookie).send({
-        requestStartDateTime: '2023-05-05T12:00:00.000Z',
-        requestEndDateTime: '2023-05-06T12:00:00.000Z',
-        title: 'modified-title',
-        content: 'modified-content',
-        startDateTime: '2023-05-06T00:00:00.000Z',
-        endDateTime: '2023-05-07T00:00:00.000Z',
-        recurrence: 1,
-        freq: 'DAILY',
-        interval: 1,
-        byweekday: null,
-        until: '2026-01-05T00:00:00.000Z',
-      });
-
-      const expectedResult = {
-        scheduleSummary: {
-          id: 1,
-          groupId: 1,
-          startDateTime: '2023-05-06T00:00:00.000Z',
-          endDateTime: '2023-05-07T00:00:00.000Z',
-          recurrence: 1,
-          freq: 'DAILY',
-          interval: 1,
-          byweekday: null,
-          startRecur: '2023-05-06T00:00:00.000Z',
-          endRecur: '2026-01-05T00:00:00.000Z',
-          isGroup: 1
-        },
-        todaySchedules: [
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-06T00:00:00.000Z',
-            endDateTime: '2023-05-07T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          }
-        ],
-        schedulesForTheWeek: [
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-07T00:00:00.000Z',
-            endDateTime: '2023-05-08T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-08T00:00:00.000Z',
-            endDateTime: '2023-05-09T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-09T00:00:00.000Z',
-            endDateTime: '2023-05-10T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-10T00:00:00.000Z',
-            endDateTime: '2023-05-11T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-11T00:00:00.000Z',
-            endDateTime: '2023-05-12T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          },
-          {
-            id: 1,
-            groupId: 1,
-            title: 'modified-title',
-            content: 'modified-content',
-            startDateTime: '2023-05-12T00:00:00.000Z',
-            endDateTime: '2023-05-13T00:00:00.000Z',
-            recurrence: 1,
-            freq: 'DAILY',
-            interval: 1,
-            byweekday: null,
-            startRecur: '2023-05-06T00:00:00.000Z',
-            endRecur: '2026-01-05T00:00:00.000Z',
-            isGroup: 1
-          }
-        ]
-      };
-
-      const modifiedSchedule = await GroupSchedule.findOne({
-        where: { title: 'modified-title', content: 'modified-content' },
-      });
-
-      expect(modifiedSchedule.id).toEqual(1);
-      expect(res.status).toEqual(201);
-      expect(res.body).toEqual(expectedResult);
-    });
-  });
-
   describe('Test DELETE /api/group/:group_id/calendar', () => {
     it('Group schedule deleted successfully ', async () => {
       const groupId = 1;
@@ -2320,3 +2022,150 @@ describe('Test /api/group endpoints', () => {
     });
   });
 });
+
+/*
+describe('Test POST /api/group/:group_id/calendar', () => {
+    it('Group schedule creation successful ', async () => {
+      const groupId = 1;
+      const res = await request(app).post(`/api/group/${groupId}/calendar`).set('Cookie', cookie).send({
+        requestStartDateTime: '2023-05-05T12:00:00.000Z',
+        requestEndDateTime: '2023-05-06T12:00:00.000Z',
+        title: 'test-title',
+        content: 'test-content',
+        startDateTime: '2023-05-06T00:00:00.000Z',
+        endDateTime: '2023-05-07T00:00:00.000Z',
+        recurrence: 1,
+        freq: 'DAILY',
+        interval: 1,
+        byweekday: null,
+        until: '2026-01-05T00:00:00.000Z'
+      });
+      const expectedResult = {
+        scheduleSummary: {
+          id: 24,
+          groupId: 1,
+          startDateTime: '2023-05-06T00:00:00.000Z',
+          endDateTime: '2023-05-07T00:00:00.000Z',
+          recurrence: 1,
+          freq: 'DAILY',
+          interval: 1,
+          byweekday: null,
+          startRecur: '2023-05-06T00:00:00.000Z',
+          endRecur: '2026-01-05T00:00:00.000Z',
+          isGroup: 1
+        },
+        todaySchedules: [
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-06T00:00:00.000Z',
+            endDateTime: '2023-05-07T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          }
+        ],
+        schedulesForTheWeek: [
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-07T00:00:00.000Z',
+            endDateTime: '2023-05-08T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          },
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-08T00:00:00.000Z',
+            endDateTime: '2023-05-09T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          },
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-09T00:00:00.000Z',
+            endDateTime: '2023-05-10T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          },
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-10T00:00:00.000Z',
+            endDateTime: '2023-05-11T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          },
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-11T00:00:00.000Z',
+            endDateTime: '2023-05-12T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          },
+          {
+            id: 24,
+            groupId: 1,
+            title: 'test-title',
+            content: 'test-content',
+            startDateTime: '2023-05-12T00:00:00.000Z',
+            endDateTime: '2023-05-13T00:00:00.000Z',
+            recurrence: 1,
+            freq: 'DAILY',
+            interval: 1,
+            byweekday: null,
+            startRecur: '2023-05-06T00:00:00.000Z',
+            endRecur: '2026-01-05T00:00:00.000Z',
+            isGroup: 1
+          }
+        ]
+      };
+      expect(res.status).toEqual(201);
+      expect(res.body).toEqual(expectedResult);
+    });
+  });
+*/

--- a/__test__/dbSetup.js
+++ b/__test__/dbSetup.js
@@ -7,6 +7,8 @@ const PersonalSchedule = require('../src/models/personalSchedule');
 const Post = require('../src/models/post');
 const Comment = require('../src/models/comment');
 const Like = require('../src/models/like');
+const Vote = require('../src/models/vote');
+const VoteResult = require('../src/models/voteResult');
 
 const mockUser = {
   email: 'test-user1@email.com',
@@ -451,6 +453,37 @@ async function setUpLikeDB() {
   ]);
 }
 
+async function setUpVoteDB() {
+  await Vote.bulkCreate([
+    {
+      voteId: 1, title: 'test-title1', content: 'test-content1', startDateTime: '2023-02-03T00:00:00.000Z', endDateTime: '2023-05-15T23:59:59.999Z', recurrence: 0, groupId: 1, votingEndDate: '2023-12-01T00:00:00.000Z',
+    },
+    {
+      voteId: 2, title: 'test-title2', content: 'test-content2', startDateTime: '2023-04-15T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0, groupId: 1, votingEndDate: '2023-12-01T00:00:00.000Z',
+    },
+    {
+      voteId: 3, title: 'test-title3', content: 'test-content3', startDateTime: '2023-04-10T00:00:00.000Z', endDateTime: '2023-04-15T23:59:59.999Z', recurrence: 0, groupId: 1, votingEndDate: '2023-12-01T00:00:00.000Z',
+    },
+    {
+      voteId: 4, title: 'test-title4', content: 'test-content4', startDateTime: '2023-04-01T00:00:00.000Z', endDateTime: '2023-04-30T23:59:59.999Z', recurrence: 0, groupId: 1, votingEndDate: '2023-12-01T00:00:00.000Z',
+    },
+  ]);
+}
+
+async function setUpVoteResultDB() {
+  await VoteResult.bulkCreate([
+    {
+      resultId: 1, choice: true, userId: 1, voteId: 1,
+    },
+    {
+      resultId: 2, choice: true, userId: 1, voteId: 2,
+    },
+    {
+      resultId: 3, choice: true, userId: 1, voteId:3,
+    },
+  ]);
+}
+
 async function tearDownUserDB() {
   await db.sequelize.query('DELETE FROM users');
 }
@@ -476,6 +509,14 @@ async function tearDownLikeDB() {
   await db.sequelize.query('DELETE FROM `like`');
 }
 
+async function tearDownVoteDB() {
+  await db.sequelize.query('DELETE FROM votes');
+}
+
+async function tearDownVoteResultDB() {
+  await db.sequelize.query('DELETE FROM voteResults');
+}
+
 module.exports = {
   db,
   mockUser,
@@ -487,12 +528,16 @@ module.exports = {
   setUpGroupScheduleDB2,
   setUpGroupPostDB,
   setUpLikeDB,
+  setUpVoteDB,
+  setUpVoteResultDB,
   tearDownUserDB,
   tearDownGroupDB,
   tearDownGroupScheduleDB,
   tearDownPersonalScheduleDB,
   tearDownGroupPostDB,
   tearDownLikeDB,
+  tearDownVoteDB,
+  tearDownVoteResultDB,
   syncDB,
   dropDB,
 };

--- a/src/controllers/groupSchedule.js
+++ b/src/controllers/groupSchedule.js
@@ -9,6 +9,9 @@ const PersonalSchedule = require('../models/personalSchedule');
 const Group = require('../models/group');
 const GroupSchedule = require('../models/groupSchedule');
 const UserGroup = require('../models/userGroup');
+const User = require('../models/user');
+const Vote = require('../models/vote');
+const VoteResult = require('../models/voteResult');
 
 // Error
 const {
@@ -19,62 +22,14 @@ const {
 // Validator
 const {
   validateGroupIdSchema, validateEventProposalSchema,
-  validateScheduleSchema, validateScheduleDateSchema,
+  validateScheduleDateSchema,
   validateGroupScheduleIdSchema,
+  validateScheduleProposalSchema,
+  validateScheduleProposalIdSchema,
+  validateGroupScheduleConfirmSchema,
+  validateVoteSchema,
 } = require('../utils/validators');
 const { getScheduleResponse } = require('../utils/rrule');
-
-async function postGroupSchedule(req, res, next) {
-  try {
-    const { error: bodyError } = validateScheduleSchema(req.body);
-    const { error: paramError } = validateGroupIdSchema(req.params);
-
-    if (paramError) {
-      return next(new DataFormatError(paramError.details[0].message));
-    }
-
-    if (bodyError) {
-      return next(new DataFormatError(bodyError.details[0].message));
-    }
-
-    const { group_id: groupId } = req.params;
-    const { user } = req;
-    const group = await Group.findByPk(groupId);
-    if (!group) {
-      return next(new GroupNotFoundError());
-    }
-
-    const accessLevel = await getAccessLevel(user, group);
-    if (accessLevel === 'viewer' || accessLevel === 'regular') {
-      return next(new EditPermissionError());
-    }
-
-    const {
-      requestStartDateTime, requestEndDateTime,
-      title, content, startDateTime, endDateTime,
-      recurrence, freq, interval, byweekday, until,
-    } = req.body;
-
-    const groupSchedule = await GroupSchedule.create({
-      groupId: group.groupId,
-      title,
-      content,
-      startDateTime,
-      endDateTime,
-      recurrence,
-      freq,
-      interval,
-      byweekday,
-      until,
-    });
-
-    const response = await getScheduleResponse(requestStartDateTime, requestEndDateTime, groupSchedule.dataValues, true);
-
-    return res.status(201).json(response);
-  } catch (err) {
-    return next(new ApiError());
-  }
-}
 
 async function getSingleGroupSchedule(req, res, next) {
   try {
@@ -196,62 +151,6 @@ async function getGroupScheduleSummary(req, res, next) {
   }
 }
 
-async function putGroupSchedule(req, res, next) {
-  try {
-    const { error: paramError } = validateGroupScheduleIdSchema(req.params);
-    const { error: bodyError } = validateScheduleSchema(req.body);
-
-    if (paramError || bodyError) {
-      return next(new DataFormatError());
-    }
-
-    const { schedule_id: scheduleId, group_id: groupId } = req.params;
-    const { user } = req;
-    const [group, schedule] = await Promise.all([
-      Group.findByPk(groupId),
-      GroupSchedule.findOne({ where: { groupId, id: scheduleId } }),
-    ]);
-
-    if (!group) {
-      return next(new GroupNotFoundError());
-    }
-
-    if (!schedule) {
-      return next(new ScheduleNotFoundError());
-    }
-
-    const accessLevel = await getAccessLevel(user, group);
-    if (accessLevel === 'viewer' || accessLevel === 'regular') {
-      return next(new EditPermissionError());
-    }
-
-    const {
-      requestStartDateTime, requestEndDateTime,
-      title, content, startDateTime, endDateTime,
-      recurrence, freq, interval, byweekday, until,
-    } = req.body;
-
-    await schedule.update({
-      groupId: group.groupId,
-      title,
-      content,
-      startDateTime,
-      endDateTime,
-      recurrence,
-      freq,
-      interval,
-      byweekday,
-      until,
-    });
-    const modifiedSchedule = await GroupSchedule.findByPk(scheduleId);
-    const response = await getScheduleResponse(requestStartDateTime, requestEndDateTime, modifiedSchedule.dataValues, true);
-
-    return res.status(201).json(response);
-  } catch (err) {
-    return next(new ApiError());
-  }
-}
-
 async function deleteGroupSchedule(req, res, next) {
   try {
     const { error: paramError } = validateGroupScheduleIdSchema(req.params);
@@ -287,7 +186,298 @@ async function deleteGroupSchedule(req, res, next) {
   }
 }
 
-async function getEventProposal(req, res, next) {
+async function postScheduleProposal(req, res, next) {
+  try {
+    const { error: paramError } = validateGroupIdSchema(req.params);
+    const { error: bodyError } = validateScheduleProposalSchema(req.body);
+
+    if (paramError) {
+      return next(new DataFormatError(paramError.details[0].message));
+    }
+
+    if (bodyError) {
+      return next(new DataFormatError(bodyError.details[0].message));
+    }
+
+    const { group_id: groupId } = req.params;
+    const { user } = req;
+    const group = await Group.findByPk(groupId);
+    if (!group) {
+      return next(new GroupNotFoundError());
+    }
+
+    const accessLevel = await getAccessLevel(user, group);
+    if (accessLevel === 'viewer' || accessLevel === 'regular') {
+      return next(new EditPermissionError());
+    }
+
+    const {
+      title, content, startDateTime, endDateTime,
+      recurrence, freq, interval, byweekday, until,
+    } = req.body;
+
+    // 투표 종료일은 후보 등록 후 7일후로 고정.
+    const votingEndDate = moment.utc().add(7, 'days').toDate();
+    const pendingSchedule = await Vote.create({
+      groupId: group.groupId,
+      title,
+      content,
+      startDateTime,
+      endDateTime,
+      recurrence,
+      freq,
+      interval,
+      byweekday,
+      until,
+      votingEndDate,
+    });
+
+    return res.status(200).json(pendingSchedule);
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function getScheduleProposal(req, res, next) {
+  try {
+    const { error: paramError } = validateScheduleProposalIdSchema(req.params);
+    if (paramError) {
+      return next(new DataFormatError());
+    }
+
+    const { group_id: groupId, proposal_id: proposalId } = req.params;
+    const [group, pendingSchedule] = await Promise.all([
+      Group.findByPk(groupId),
+      Vote.findOne({
+        where: {
+          groupId,
+          voteId: proposalId,
+        },
+      }),
+    ]);
+
+    if (!group) {
+      return next(new GroupNotFoundError());
+    }
+
+    if (!pendingSchedule) {
+      return next(new ScheduleNotFoundError());
+    }
+
+    return res.status(200).json(pendingSchedule);
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function getScheduleProposalsList(req, res, next) {
+  try {
+    const { error: paramError } = validateGroupIdSchema(req.params);
+    if (paramError) {
+      return next(new DataFormatError());
+    }
+
+    const { group_id: groupId } = req.params;
+    const [group, pendingSchedules] = await Promise.all([
+      Group.findByPk(groupId),
+      Vote.findAll({
+        where: {
+          groupId,
+        },
+        include: [
+          {
+            model: VoteResult,
+            attributes: ['userId', 'choice'],
+            include: {
+              model: User,
+              attributes: ['nickname', 'profileImage'],
+            },
+          },
+        ],
+      }),
+    ]);
+
+    if (!group) {
+      return next(new GroupNotFoundError());
+    }
+
+    if (!pendingSchedules) {
+      return next(new ScheduleNotFoundError());
+    }
+
+    const response = await Promise.all(pendingSchedules.map(async (pendingSchedule) => {
+      const votesCount = await VoteResult.count({
+        where: { voteId: pendingSchedule.voteId, choice: true },
+      });
+
+      return {
+        voteId: pendingSchedule.voteId,
+        title: pendingSchedule.title,
+        content: pendingSchedule.content,
+        startDateTime: pendingSchedule.startDateTime,
+        endDateTime: pendingSchedule.endDateTime,
+        recurrence: pendingSchedule.recurrence,
+        freq: pendingSchedule.freq,
+        interval: pendingSchedule.interval,
+        byweekday: pendingSchedule.byweekday,
+        until: pendingSchedule.until,
+        votingEndDate: pendingSchedule.votingEndDate,
+        groupId: pendingSchedule.groupId,
+        votesCount,
+        voteResults: pendingSchedule.dataValues.VoteResults,
+      };
+    }));
+    return res.status(200).json(response);
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function deleteScheduleProposal(req, res, next) {
+  try {
+    const { error: paramError } = validateScheduleProposalIdSchema(req.params);
+    if (paramError) {
+      return next(new DataFormatError());
+    }
+
+    const { group_id: groupId, proposal_id: proposalId } = req.params;
+    const [group, pendingSchedule] = await Promise.all([
+      Group.findByPk(groupId),
+      Vote.findOne({
+        where: {
+          groupId,
+          voteId: proposalId,
+        },
+      }),
+    ]);
+
+    if (!group) {
+      return next(new GroupNotFoundError());
+    }
+
+    if (!pendingSchedule) {
+      return next(new ScheduleNotFoundError());
+    }
+
+    await pendingSchedule.destroy();
+    return res.status(204).end();
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function postScheduleProposalVote(req, res, next) {
+  try {
+    const { error: paramError } = validateScheduleProposalIdSchema(req.params);
+    const { error: bodyError } = validateVoteSchema(req.body);
+    if (paramError || bodyError) {
+      return next(new DataFormatError());
+    }
+
+    const { group_id: groupId, proposal_id: proposalId } = req.params;
+    const { user } = req;
+    const [group, pendingSchedule] = await Promise.all([
+      Group.findByPk(groupId),
+      Vote.findOne({
+        where: {
+          groupId,
+          voteId: proposalId,
+        },
+      }),
+    ]);
+
+    if (!group) {
+      return next(new GroupNotFoundError());
+    }
+
+    if (!pendingSchedule) {
+      return next(new ScheduleNotFoundError());
+    }
+
+    const { attendance } = req.body;
+    const voteResult = await VoteResult.findOne({
+      where: {
+        userId: user.userId,
+        voteId: pendingSchedule.voteId,
+      },
+    });
+    if (voteResult) {
+      voteResult.update({ choice: attendance });
+    } else {
+      await VoteResult.create({
+        userId: user.userId,
+        voteId: pendingSchedule.voteId,
+        choice: attendance,
+      });
+    }
+
+    return res.status(200).end();
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function postScheduleProposalConfirm(req, res, next) {
+  try {
+    const { error: paramError } = validateScheduleProposalIdSchema(req.params);
+    const { error: bodyError } = validateGroupScheduleConfirmSchema(req.body);
+    if (paramError || bodyError) {
+      return next(new DataFormatError());
+    }
+
+    const { group_id: groupId, proposal_id: proposalId } = req.params;
+    const { user } = req;
+    const [group, pendingSchedule] = await Promise.all([
+      Group.findByPk(groupId),
+      Vote.findOne({
+        where: {
+          groupId,
+          voteId: proposalId,
+        },
+      }),
+    ]);
+
+    if (!group) {
+      return next(new GroupNotFoundError());
+    }
+
+    if (!pendingSchedule) {
+      return next(new ScheduleNotFoundError());
+    }
+
+    const accessLevel = await getAccessLevel(user, group);
+    if (accessLevel === 'viewer' || accessLevel === 'regular') {
+      return next(new EditPermissionError());
+    }
+
+    const {
+      requestStartDateTime, requestEndDateTime,
+    } = req.body;
+
+    const groupSchedule = await GroupSchedule.create({
+      groupId: group.groupId,
+      title: pendingSchedule.title,
+      content: pendingSchedule.content,
+      startDateTime: pendingSchedule.startDateTime,
+      endDateTime: pendingSchedule.endDateTime,
+      recurrence: pendingSchedule.recurrence,
+      freq: pendingSchedule.freq,
+      interval: pendingSchedule.interval,
+      byweekday: pendingSchedule.byweekday,
+      until: pendingSchedule.until,
+    });
+
+    await pendingSchedule.destroy();
+
+    const response = await getScheduleResponse(requestStartDateTime, requestEndDateTime, groupSchedule.dataValues, true);
+
+    return res.status(201).json(response);
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function getScheduleProposals(req, res, next) {
   try {
     const { error: paramError } = validateGroupIdSchema(req.params);
     const { error: queryError } = validateEventProposalSchema(req.query);
@@ -318,30 +508,28 @@ async function getEventProposal(req, res, next) {
     })).map((member) => member.userId);
     const proposal = {};
 
-    /* eslint-disable no-restricted-syntax */
-    for (const date of Object.values(req.query)) {
-      const start = moment.utc(date).toDate();
-      const end = moment.utc(date).add(24, 'hours').add(-1, 's').toDate();
-      /* eslint-disable-next-line no-await-in-loop */
-      const userSchedules = await PersonalSchedule.getProposalSchedule(groupMembers, start, end);
-      /* eslint-disable-next-line no-await-in-loop */
-      const groupSchedules = await GroupSchedule.getProposalSchedule([groupId], start, end);
-      const events = [...userSchedules, ...groupSchedules];
-      events.sort((a, b) => a.startDateTime.getTime() - b.startDateTime.getTime());
+    const { startDateTime, endDateTime, duration } = req.query;
+    const start = moment.utc(startDateTime).toDate();
+    const end = moment.utc(endDateTime).toDate();
+    /* eslint-disable-next-line no-await-in-loop */
+    const userSchedules = await PersonalSchedule.getProposalSchedule(groupMembers, start, end);
+    /* eslint-disable-next-line no-await-in-loop */
+    const groupSchedules = await GroupSchedule.getProposalSchedule([groupId], start, end);
+    const events = [...userSchedules, ...groupSchedules];
+    events.sort((a, b) => a.startDateTime.getTime() - b.startDateTime.getTime());
 
-      // 결과값에서 9시~22시 사이의 값들을 먼저 추천할 수 있도록 정렬.
-      const result = eventProposal(events, start, end);
-      const filteredTimes = result.filter((event) => (
-        event.startDateTime.getTime() < (end.getTime() - 1000 * 60 * 60 * 2)
-          && event.endDateTime.getTime() > (start.getTime() + 1000 * 60 * 60 * 9)
-      ));
-      const remainingTimes = result.filter((event) => (
-        event.startDateTime.getTime() >= (end.getTime() - 1000 * 60 * 60 * 2)
-          || event.endDateTime.getTime() <= (start.getTime() + 1000 * 60 * 60 * 9)
-      ));
-      const sortedResult = filteredTimes.concat(remainingTimes);
-      proposal[date] = sortedResult;
-    }
+    // 결과값에서 9시~22시 사이의 값들을 먼저 추천할 수 있도록 정렬.
+    const result = eventProposal(events, start, end, duration);
+    const filteredTimes = result.filter((event) => (
+      event.startDateTime.getTime() < (end.getTime() - 1000 * 60 * 60 * 2)
+        && event.endDateTime.getTime() > (start.getTime() + 1000 * 60 * 60 * 9)
+    ));
+    const remainingTimes = result.filter((event) => (
+      event.startDateTime.getTime() >= (end.getTime() - 1000 * 60 * 60 * 2)
+        || event.endDateTime.getTime() <= (start.getTime() + 1000 * 60 * 60 * 9)
+    ));
+    const sortedResult = filteredTimes.concat(remainingTimes);
+    proposal['proposals'] = sortedResult;
 
     return res.status(200).json(proposal);
   } catch (err) {
@@ -350,11 +538,15 @@ async function getEventProposal(req, res, next) {
 }
 
 module.exports = {
-  postGroupSchedule,
   getSingleGroupSchedule,
   getGroupSchedule,
   getGroupScheduleSummary,
-  putGroupSchedule,
   deleteGroupSchedule,
-  getEventProposal,
+  postScheduleProposal,
+  getScheduleProposal,
+  getScheduleProposalsList,
+  deleteScheduleProposal,
+  postScheduleProposalVote,
+  postScheduleProposalConfirm,
+  getScheduleProposals,
 };

--- a/src/controllers/groupSchedule.js
+++ b/src/controllers/groupSchedule.js
@@ -467,7 +467,11 @@ async function postScheduleProposalConfirm(req, res, next) {
       until: pendingSchedule.until,
     });
 
-    await pendingSchedule.destroy();
+    await Vote.destroy({
+      where: {
+        groupId,
+      },
+    });
 
     const response = await getScheduleResponse(requestStartDateTime, requestEndDateTime, groupSchedule.dataValues, true);
 
@@ -529,7 +533,7 @@ async function getScheduleProposals(req, res, next) {
         || event.endDateTime.getTime() <= (start.getTime() + 1000 * 60 * 60 * 9)
     ));
     const sortedResult = filteredTimes.concat(remainingTimes);
-    proposal['proposals'] = sortedResult;
+    proposal.proposals = sortedResult;
 
     return res.status(200).json(proposal);
   } catch (err) {

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -68,6 +68,10 @@ class Group extends Sequelize.Model {
       foreignKey: 'groupId',
       onDelete: 'cascade',
     });
+    db.Group.hasMany(db.Vote, {
+      foreignKey: 'groupId',
+      onDelete: 'cascade',
+    });
   }
 }
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -72,6 +72,10 @@ class User extends Sequelize.Model {
       foreignKey: 'userId',
       onDelete: 'cascade',
     });
+    db.User.hasMany(db.VoteResult, {
+      foreignKey: 'userId',
+      onDelete: 'cascade',
+    });
   }
 }
 

--- a/src/models/vote.js
+++ b/src/models/vote.js
@@ -1,0 +1,75 @@
+const Sequelize = require('sequelize');
+
+class Vote extends Sequelize.Model {
+  static initiate(sequelize) {
+    Vote.init({
+      voteId: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      title: {
+        type: Sequelize.STRING(45),
+        allowNull: false,
+      },
+      content: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      startDateTime: {
+        type: Sequelize.DATE(3),
+        allowNull: false,
+      },
+      endDateTime: {
+        type: Sequelize.DATE(3),
+        allowNull: false,
+      },
+      recurrence: {
+        type: Sequelize.TINYINT(1),
+        allowNull: false,
+      },
+      freq: {
+        type: Sequelize.STRING(10),
+        allowNull: true,
+      },
+      interval: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      byweekday: {
+        type: Sequelize.JSON,
+        allowNull: true,
+      },
+      until: {
+        type: Sequelize.DATE(3),
+        allowNull: true,
+      },
+      votingEndDate: {
+        type: Sequelize.DATE(3),
+        allowNull: false,
+      },
+    }, {
+      sequelize,
+      timestamps: true,
+      underscored: false,
+      modelName: 'Vote',
+      tableName: 'votes',
+      paranoid: false,
+      charset: 'utf8',
+      collate: 'utf8_general_ci',
+    });
+  }
+
+  static associate(db) {
+    db.Vote.belongsTo(db.Group, {
+      foreignKey: 'groupId',
+    });
+    db.Vote.hasMany(db.VoteResult, {
+      foreignKey: 'voteId',
+      onDelete: 'cascade',
+    });
+  }
+}
+
+module.exports = Vote;

--- a/src/models/voteResult.js
+++ b/src/models/voteResult.js
@@ -15,7 +15,7 @@ class VoteResult extends Sequelize.Model {
       },
     }, {
       sequelize,
-      timestamps: true,
+      timestamps: false,
       underscored: false,
       modelName: 'VoteResult',
       tableName: 'votesResults',

--- a/src/models/voteResult.js
+++ b/src/models/voteResult.js
@@ -18,7 +18,7 @@ class VoteResult extends Sequelize.Model {
       timestamps: false,
       underscored: false,
       modelName: 'VoteResult',
-      tableName: 'votesResults',
+      tableName: 'voteResults',
       paranoid: false,
       charset: 'utf8',
       collate: 'utf8_general_ci',

--- a/src/models/voteResult.js
+++ b/src/models/voteResult.js
@@ -1,0 +1,38 @@
+const Sequelize = require('sequelize');
+
+class VoteResult extends Sequelize.Model {
+  static initiate(sequelize) {
+    VoteResult.init({
+      resultId: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      choice: {
+        type: Sequelize.TINYINT,
+        allowNull: false,
+      },
+    }, {
+      sequelize,
+      timestamps: true,
+      underscored: false,
+      modelName: 'VoteResult',
+      tableName: 'votesResults',
+      paranoid: false,
+      charset: 'utf8',
+      collate: 'utf8_general_ci',
+    });
+  }
+
+  static associate(db) {
+    db.VoteResult.belongsTo(db.Vote, {
+      foreignKey: 'voteId',
+    });
+    db.VoteResult.belongsTo(db.User, {
+      foreignKey: 'userId',
+    });
+  }
+}
+
+module.exports = VoteResult;

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -3,7 +3,7 @@ const express = require('express');
 // Group
 const {
   postGroup,
-  getGroupInfo, getGroupDetail, getGroupList,
+  getGroupDetail, getGroupList,
   putGroup, deleteGroup,
   getGroupMembers, getPendingMembers,
   postGroupJoinRequest, postGroupJoinApprove, postGroupJoinReject,
@@ -39,7 +39,6 @@ const router = express.Router();
 router.post('/', uploadGroupMiddleware, postGroup);
 router.get('/list', getGroupList);
 router.get('/search', searchGroup);
-router.get('/:group_id/info', getGroupInfo);
 router.get('/:group_id', getGroupDetail);
 router.put('/:group_id', uploadGroupMiddleware, putGroup);
 router.delete('/:group_id', deleteGroup);

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -67,6 +67,7 @@ router.get('/:group_id/proposals', getScheduleProposals);
 router.get('/:group_id/proposal/list', getScheduleProposalsList);
 router.get('/:group_id/proposal/:proposal_id', getScheduleProposal);
 router.delete('/:group_id/proposal/:proposal_id', deleteScheduleProposal);
+
 router.post('/:group_id/proposal/:proposal_id/vote', postScheduleProposalVote);
 router.post('/:group_id/proposal/:proposal_id/confirm', postScheduleProposalConfirm);
 

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -17,8 +17,10 @@ const {
 // Schedule
 const {
   getGroupSchedule, getSingleGroupSchedule, getGroupScheduleSummary,
-  postGroupSchedule, putGroupSchedule, deleteGroupSchedule,
-  getEventProposal,
+  deleteGroupSchedule,
+  postScheduleProposal, getScheduleProposal, getScheduleProposalsList, deleteScheduleProposal,
+  postScheduleProposalVote, postScheduleProposalConfirm,
+  getScheduleProposals,
 } = require('../controllers/groupSchedule');
 
 // Feed
@@ -54,13 +56,19 @@ router.post('/:group_id/join/:inviteCode', postJoinGroupWithInviteCode);
 router.patch('/:group_id/members/:user_id/access-level', patchUserAccessLevel);
 
 // Schedule
-router.post('/:group_id/calendar', postGroupSchedule);
 router.get('/:group_id/calendar', getGroupSchedule);
 router.get('/:group_id/calendar/summary', getGroupScheduleSummary);
 router.get('/:group_id/calendar/:schedule_id', getSingleGroupSchedule);
-router.put('/:group_id/calendar/:schedule_id', putGroupSchedule);
 router.delete('/:group_id/calendar/:schedule_id', deleteGroupSchedule);
-router.get('/:group_id/proposal', getEventProposal);
+
+// Schedule Vote단일 일정 후보를 사용자가 직접 등록해서 CRUD
+router.post('/:group_id/proposal', postScheduleProposal);
+router.get('/:group_id/proposals', getScheduleProposals);
+router.get('/:group_id/proposal/list', getScheduleProposalsList);
+router.get('/:group_id/proposal/:proposal_id', getScheduleProposal);
+router.delete('/:group_id/proposal/:proposal_id', deleteScheduleProposal);
+router.post('/:group_id/proposal/:proposal_id/vote', postScheduleProposalVote);
+router.post('/:group_id/proposal/:proposal_id/confirm', postScheduleProposalConfirm);
 
 // Feed
 router.post('/:group_id/post', uploadPostMiddleware, postGroupPost);

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -1647,19 +1647,23 @@
             "name": "startDateTime",
             "in": "query",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "example": "2099-01-01T12:00:00.000Z"
           },
           {
             "name": "endDateTime",
             "in": "query",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "example": "2099-01-08T12:00:00.000Z"
           },
           {
             "name": "duration",
+            "description": "일정 최소 시간(minute)",
             "in": "query",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "example": 60
           }
         ],
         "responses": {
@@ -1670,6 +1674,18 @@
                 "examples": {
                   "successExample": {
                     "value": {
+                      "proposals": [
+                        {
+                          "startDateTime": "추천 시작 시간",
+                          "endDateTime": "추천 종료 시간",
+                          "duration": "구간의 길이(분 단위)"
+                        },
+                        {
+                          "startDateTime": "추천 시작 시간",
+                          "endDateTime": "추천 종료 시간",
+                          "duration": "구간의 길이(분 단위)"
+                        }
+                      ]
                     }
                   }
                 }

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -495,7 +495,8 @@
                           "inviteCode": "그룹 초대 코드",
                           "inviteExp": "초대 코드 만료일",
                           "isPublicGroup": "BOOLEAN, 공개 그룹 여부",
-                          "image": "그룹 대표 이미지 주소"
+                          "image": "그룹 대표 이미지 주소",
+                          "feedCount": "작성된 피드 개수"
                         },
                         "leaderInfo": {
                           "userId": "유저 식별자",
@@ -632,56 +633,6 @@
           },
           "404": {
             "description": "존재하지 않는 유저/그룹"
-          },
-          "500": {
-            "description": "서버 에러"
-          }
-        }
-      }
-    },
-    "/api/group/{group_id}/info": {
-      "get": {
-        "description": "단일 그룹의 groupId, 그룹명, 소개, 멤버 수, 피드 갯수를 보여줍니다",
-        "summary": "단일 그룹 정보 조회",
-        "tags": ["Group"],
-        "parameters": [
-          {
-            "name": "group_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "성공",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "successExample": {
-                    "value": {
-                      "accessLevel": "viewer, regular, admin, owner와 같은 접근 권한을 리턴",
-                      "information": {
-                        "groupId": "그룹 식별자",
-                        "name": "그룹 이름",
-                        "description": "그룹 소개",
-                        "member": "멤버 수",
-                        "feed": "그룹 피드 개수"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "형식에 맞지 않는 데이터"
-          },
-          "401": {
-            "description": "권한 없음"
-          },
-          "404": {
-            "description": "존재하지 않는 그룹"
           },
           "500": {
             "description": "서버 에러"

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -1196,230 +1196,6 @@
       }
     },
     "/api/group/{group_id}/calendar": {
-      "post": {
-        "description": "",
-        "summary": "그룹 일정 등록",
-        "tags": ["Group Schedule"],
-        "parameters": [
-          {
-            "name": "group_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "requestStartDateTime" : {
-                    "example": "2099-01-01T12:00:00.000Z",
-                    "type": "DATETIME"
-                  },
-                  "requestEndDateTime" : {
-                    "example": "2099-01-02T12:00:00.000Z",
-                    "type": "DATETIME"
-                  },
-                  "title": {
-                    "example": "test-title",
-                    "type": "VARCHAR(45)"
-                  },
-                  "content": {
-                    "example": "test-content",
-                    "type": "VARCHAR(300)"
-                  },
-                  "startDateTime": {
-                    "example": "2099-01-01T12:00:00.000Z",
-                    "type": "DATETIME"
-                  },
-                  "endDateTime": {
-                    "example": "2099-01-01T13:00:00.000Z",
-                    "type": "DATETIME"
-                  },
-                  "recurrence": {
-                    "example": 0,
-                    "type": "TINYINT(1)"
-                  },
-                  "freq": {
-                    "example": null,
-                    "type": "ENUM(DAILY, WEEKLY, MONTHLY, YEARLY)"
-                  },
-                  "interval": {
-                    "example": null,
-                    "type": "integer"
-                  },
-                  "byweekday": {
-                    "example": null,
-                    "type": "TEXT"
-                  },
-                  "until": {
-                    "example": null,
-                    "type": "DATETIME"
-                  }
-                }
-              },
-              "examples": {
-                "non-recurrence": {
-                  "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
-                    "title": "test-title",
-                    "content": "test-content",
-                    "startDateTime": "2099-01-01T12:00:00.000Z",
-                    "endDateTime": "2099-01-01T13:00:00.000Z",
-                    "recurrence": 0,
-                    "freq": null,
-                    "interval": null,
-                    "byweekday": null,
-                    "until": null
-                  }
-                },
-                "recurrence1": {
-                  "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
-                    "title": "test-title",
-                    "content": "test-content",
-                    "startDateTime": "2099-01-01T12:00:00.000Z",
-                    "endDateTime": "2099-01-01T13:00:00.000Z",
-                    "recurrence": 1,
-                    "freq": "DAILY",
-                    "interval": 1,
-                    "byweekday": null,
-                    "until": "2099-02-01T00:00:00.000Z"
-                  },
-                  "description": "매일 반복되는 일정 등록 예시"
-                },
-                "recurrence2": {
-                  "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
-                    "title": "test-title",
-                    "content": "test-content",
-                    "startDateTime": "2099-01-01T12:00:00.000Z",
-                    "endDateTime": "2099-01-01T13:00:00.000Z",
-                    "recurrence": 1,
-                    "freq": "WEEKLY",
-                    "interval": 1,
-                    "byweekday": [4],
-                    "until": "2099-02-01T00:00:00.000Z"
-                  },
-                  "description": "주간 반복 일정 등록 예시, byweekday 배열에 해당 날짜의 요일을 필수적으로 포함."
-                },
-                "recurrence3": {
-                  "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
-                    "title": "test-title",
-                    "content": "test-content",
-                    "startDateTime": "2099-01-01T12:00:00.000Z",
-                    "endDateTime": "2099-01-01T13:00:00.000Z",
-                    "recurrence": 1,
-                    "freq": "WEEKLY",
-                    "interval": 1,
-                    "byweekday": [1, 3, 4],
-                    "until": "2099-02-01T00:00:00.000Z"
-                  },
-                  "description": "요일 반복 일정 등록 예시입니다. 일월화수목금(0123456) 요일 반복 시에, freq는 WEEKLY 고정입니다. 정수형 배열로 보내주세요."
-                },
-                "recurrence4": {
-                  "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
-                    "title": "test-title",
-                    "content": "test-content",
-                    "startDateTime": "2099-01-01T12:00:00.000Z",
-                    "endDateTime": "2099-01-01T13:00:00.000Z",
-                    "recurrence": 1,
-                    "freq": "MONTHLY",
-                    "interval": 2,
-                    "byweekday": null,
-                    "until": "2100-01-01T00:00:00.000Z"
-                  },
-                  "description": "2달마다 반복되는 월간 반복 일정 등록 예시"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "성공",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "successExample": {
-                    "value": {
-                      "scheduleSummary": {
-                        "id": "일정 식별자",
-                        "groupId": "그룹 식별자",
-                        "startDateTime": "일정 시작 일자",
-                        "endDateTime": "일정 종료 일자",
-                        "recurrence": "반복 여부",
-                        "freq": "DAILY, WEEKLY, MONTHLY, YEARLY와 같은 반복 주기",
-                        "interval": "반복 간격",
-                        "byweekday": "반복 요일",
-                        "until": "반복 종료일 (일반 일정인 경우)",
-                        "startRecur": "반복 시작 일자 (반복 일정인 경우)",
-                        "endRecur": "반복 종료 일자 (반복 일정인 경우)",
-                        "isGroup": 1
-                      },
-                      "todaySchedule": [
-                        {
-                          "id": "일정 식별자",
-                          "groupId": "그룹 식별자",
-                          "title": "일정 제목",
-                          "content": "일정 내용",
-                          "startDateTime": "일정 시작 일자",
-                          "endDateTime": "일정 종료 일자",
-                          "recurrence": "반복 여부",
-                          "freq": "DAILY, WEEKLY, MONTHLY, YEARLY와 같은 반복 주기",
-                          "interval": "반복 간격",
-                          "byweekday": "반복 요일",
-                          "until": "반복 종료일 (일반 일정인 경우)",
-                          "startRecur": "반복 시작 일자 (반복 일정인 경우)",
-                          "endRecur": "반복 종료 일자 (반복 일정인 경우)",
-                          "isGroup": 1
-                        }
-                      ],
-                      "schedulesForTheWeek": [
-                        {
-                          "id": "일정 식별자",
-                          "groupId": "그룹 식별자",
-                          "title": "일정 제목",
-                          "content": "일정 내용",
-                          "startDateTime": "일정 시작 일자",
-                          "endDateTime": "일정 종료 일자",
-                          "recurrence": "반복 여부",
-                          "freq": "DAILY, WEEKLY, MONTHLY, YEARLY와 같은 반복 주기",
-                          "interval": "반복 간격",
-                          "byweekday": "반복 요일",
-                          "until": "반복 종료일 (일반 일정인 경우)",
-                          "startRecur": "반복 시작 일자 (반복 일정인 경우)",
-                          "endRecur": "반복 종료 일자 (반복 일정인 경우)",
-                          "isGroup": 1
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "형식에 맞지 않는 데이터"
-          },
-          "401": {
-            "description": "로그인 실패"
-          },
-          "500": {
-            "description": "서버 에러"
-          }
-        }
-      },
       "get": {
         "description": "",
         "summary": "그룹 일정 조회",
@@ -1640,9 +1416,9 @@
           }
         }
       },
-      "put": {
+      "delete": {
         "description": "",
-        "summary": "그룹 일정 수정",
+        "summary": "그룹 일정 삭제",
         "tags": ["Group Schedule"],
         "parameters": [
           {
@@ -1658,6 +1434,38 @@
             "type": "integer"
           }
         ],
+        "responses": {
+          "204": {
+            "description": "성공"
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "403": {
+            "description": "존재하지 않는 일정"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/group/{group_id}/proposal": {
+      "post": {
+        "description": "",
+        "summary": "그룹 일정 후보 추가",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1665,25 +1473,21 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "requestStartDateTime" : {
+                  "title": {
+                    "example": "test-title",
+                    "type": "VARCHAR(45)"
+                  },
+                  "content": {
+                    "example": "test-content",
+                    "type": "VARCHAR(300)"
+                  },
+                  "startDateTime": {
                     "example": "2099-01-01T12:00:00.000Z",
                     "type": "DATETIME"
                   },
-                  "requestEndDateTime" : {
-                    "example": "2099-01-02T12:00:00.000Z",
-                    "type": "DATETIME"
-                  },
-                  "title": {
-                    "example": "modified-title"
-                  },
-                  "content": {
-                    "example": "modified-content"
-                  },
-                  "startDateTime": {
-                    "example": "2099-02-01T12:00:00.000Z"
-                  },
                   "endDateTime": {
-                    "example": "2099-02-01T13:00:00.000Z"
+                    "example": "2099-01-01T13:00:00.000Z",
+                    "type": "DATETIME"
                   },
                   "recurrence": {
                     "example": 0,
@@ -1710,8 +1514,6 @@
               "examples": {
                 "non-recurrence": {
                   "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
                     "title": "test-title",
                     "content": "test-content",
                     "startDateTime": "2099-01-01T12:00:00.000Z",
@@ -1725,8 +1527,6 @@
                 },
                 "recurrence1": {
                   "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
                     "title": "test-title",
                     "content": "test-content",
                     "startDateTime": "2099-01-01T12:00:00.000Z",
@@ -1741,8 +1541,6 @@
                 },
                 "recurrence2": {
                   "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
                     "title": "test-title",
                     "content": "test-content",
                     "startDateTime": "2099-01-01T12:00:00.000Z",
@@ -1757,8 +1555,6 @@
                 },
                 "recurrence3": {
                   "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
                     "title": "test-title",
                     "content": "test-content",
                     "startDateTime": "2099-01-01T12:00:00.000Z",
@@ -1773,8 +1569,6 @@
                 },
                 "recurrence4": {
                   "value": {
-                    "requestStartDateTime" : "2099-01-01T12:00:00.000Z",
-                    "requestEndDateTime" : "2099-01-02T12:00:00.000Z",
                     "title": "test-title",
                     "content": "test-content",
                     "startDateTime": "2099-01-01T12:00:00.000Z",
@@ -1786,6 +1580,349 @@
                     "until": "2100-01-01T00:00:00.000Z"
                   },
                   "description": "2달마다 반복되는 월간 반복 일정 등록 예시"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "성공",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "successExample": {
+                    "value": {
+                      "voteId": "일정 후보 식별자",
+                      "groupId": "그룹 식별자",
+                      "title": "일정 제목",
+                      "content": "일정 내용",
+                      "startDateTime": "일정 시작 일자",
+                      "endDateTime": "일정 종료 일자",
+                      "recurrence": "반복 여부",
+                      "freq": "DAILY, WEEKLY, MONTHLY, YEARLY와 같은 반복 주기",
+                      "interval": "반복 간격",
+                      "byweekday": "반복 요일",
+                      "until": "반복 종료일",
+                      "votingEndDate": "투표 종료일",
+                      "updatedAt": "마지막 업데이트 일자",
+                      "createdAt": "생성 일자"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 그룹/유저"
+          },
+          "403": {
+            "description": "수정할 권한이 없음"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/group/{group_id}/proposals": {
+      "get": {
+        "description": "",
+        "summary": "그룹 일정 후보 시간 추천 받기",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "startDateTime",
+            "in": "query",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "endDateTime",
+            "in": "query",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "duration",
+            "in": "query",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "successExample": {
+                    "value": {
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 그룹/유저"
+          },
+          "403": {
+            "description": "수정할 권한이 없음"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/group/{group_id}/proposal/list": {
+      "get": {
+        "description": "그룹 일정 후보 리스트 및 각 일정의 투표 현황을 같이 보여줍니다.",
+        "summary": "그룹 일정 후보 리스트 조회",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "successExample": {
+                    "value": {
+                      
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 그룹/유저/일정"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/group/{group_id}/proposal/{proposal_id}": {
+      "get": {
+        "description": "",
+        "summary": "그룹 일정 후보 단일 조회",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "proposal_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "successExample": {
+                    "value": {
+                      "voteId": "일정 후보 식별자",
+                      "groupId": "그룹 식별자",
+                      "title": "일정 제목",
+                      "content": "일정 내용",
+                      "startDateTime": "일정 시작 일자",
+                      "endDateTime": "일정 종료 일자",
+                      "recurrence": "반복 여부",
+                      "freq": "DAILY, WEEKLY, MONTHLY, YEARLY와 같은 반복 주기",
+                      "interval": "반복 간격",
+                      "byweekday": "반복 요일",
+                      "until": "반복 종료일",
+                      "votingEndDate": "투표 종료일",
+                      "updatedAt": "마지막 업데이트 일자",
+                      "createdAt": "생성 일자"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 그룹/유저/일정"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      },
+      "delete": {
+        "description": "",
+        "summary": "그룹 일정 후보 삭제",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "proposal_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "성공"
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 그룹/유저/일정"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/group/{group_id}/proposal/{proposal_id}/vote": {
+      "post": {
+        "description": "",
+        "summary": "그룹 일정 후보 투표",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "proposal_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "attendance": {
+                    "example": true,
+                    "type": "TINYINT(1)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "성공"
+          },
+          "400": {
+            "description": "형식에 맞지 않는 데이터"
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "404": {
+            "description": "존재하지 않는 그룹/유저/일정"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/group/{group_id}/proposal/{proposal_id}/confirm": {
+      "post": {
+        "description": "",
+        "summary": "그룹 일정 후보 확정",
+        "tags": ["Group Schedule"],
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "proposal_id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestStartDateTime" : {
+                    "example": "2099-01-01T12:00:00.000Z",
+                    "type": "DATETIME"
+                  },
+                  "requestEndDateTime" : {
+                    "example": "2099-01-02T12:00:00.000Z",
+                    "type": "DATETIME"
+                  }
                 }
               }
             }
@@ -1861,128 +1998,8 @@
           "401": {
             "description": "권한 없음"
           },
-          "403": {
-            "description": "존재하지 않는 일정"
-          },
-          "500": {
-            "description": "서버 에러"
-          }
-        }
-      },
-      "delete": {
-        "description": "",
-        "summary": "그룹 일정 삭제",
-        "tags": ["Group Schedule"],
-        "parameters": [
-          {
-            "name": "group_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          },
-          {
-            "name": "schedule_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "성공"
-          },
-          "400": {
-            "description": "형식에 맞지 않는 데이터"
-          },
-          "401": {
-            "description": "권한 없음"
-          },
-          "403": {
-            "description": "존재하지 않는 일정"
-          },
-          "500": {
-            "description": "서버 에러"
-          }
-        }
-      }
-    },
-    "/api/group/{group_id}/proposal": {
-      "get": {
-        "description": "",
-        "summary": "그룹 새 일정 시간대 추천 받기",
-        "tags": ["Group Schedule"],
-        "parameters": [
-          {
-            "name": "group_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          },
-          {
-            "name": "date1",
-            "in": "query",
-            "required": true,
-            "type": "DATETIME",
-            "example": "2099-01-01T00:00:00.000Z"
-          },
-          {
-            "name": "date2",
-            "in": "query",
-            "type": "DATETIME",
-            "example": "2099-02-01T00:00:00.000Z"
-          },
-          {
-            "name": "date3",
-            "in": "query",
-            "type": "DATETIME",
-            "example": "2099-03-01T00:00:00.000Z"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "성공",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "successExample": {
-                    "value": {
-                      "2099-01-01T00:00:00.000Z": [
-                        {
-                          "startDateTime": "2099-01-01T00:00:00.000Z",
-                          "endDateTime": "2099-01-01T12:00:00.000Z",
-                          "duration": 720
-                        },
-                        {
-                          "startDateTime": "2099-01-01T13:00:00.000Z",
-                          "endDateTime": "2099-01-01T23:59:59.000Z",
-                          "duration": 660
-                        }
-                      ],
-                      "2099-02-01T00:00:00.000Z": [
-                        {
-                          "startDateTime": "2099-02-01T00:00:00.000Z",
-                          "endDateTime": "2099-02-01T23:59:59.000Z",
-                          "duration": 1440
-                        }
-                      ],
-                      "2099-03-01T00:00:00.000Z": [
-                        {
-                          "startDateTime": "2099-03-01T00:00:00.000Z",
-                          "endDateTime": "2099-03-01T23:59:59.000Z",
-                          "duration": 1440
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "형식에 맞지 않는 데이터"
-          },
-          "401": {
-            "description": "권한 없음"
+          "404": {
+            "description": "존재하지 않는 그룹/유저/일정"
           },
           "500": {
             "description": "서버 에러"

--- a/src/utils/event.js
+++ b/src/utils/event.js
@@ -4,42 +4,54 @@ function getDuration(start, end) {
 }
 
 // events를 고려하여 빈 시간을 추출
-function eventProposal(events, start, end) {
+function eventProposal(events, start, end, minimumDuration) {
   const result = [];
   if (events.length === 0) {
-    result.push({
-      startDateTime: start,
-      endDateTime: end,
-      duration: getDuration(start, end),
-    });
+    const duration = getDuration(start, end);
+    if (duration >= minimumDuration) {
+      result.push({
+        startDateTime: start,
+        endDateTime: end,
+        duration,
+      });
+    }
     return result;
   }
   if (events[0].startDateTime.getTime() > start.getTime()) {
-    result.push({
-      startDateTime: start,
-      endDateTime: events[0].startDateTime,
-      duration: getDuration(start, events[0].startDateTime),
-    });
+    const duration = getDuration(start, events[0].startDateTime);
+    if (duration >= minimumDuration) {
+      result.push({
+        startDateTime: start,
+        endDateTime: events[0].startDateTime,
+        duration,
+      });
+    }
   }
   let currEnd = events[0].endDateTime;
   events.forEach((event) => {
     if (event.endDateTime.getTime() > currEnd.getTime()) {
       if (event.startDateTime.getTime() > currEnd.getTime()) {
-        result.push({
-          startDateTime: currEnd,
-          endDateTime: event.startDateTime,
-          duration: getDuration(currEnd, event.startDateTime),
-        });
+        const duration = getDuration(currEnd, event.startDateTime);
+        if (duration >= minimumDuration) {
+          result.push({
+            startDateTime: currEnd,
+            endDateTime: event.startDateTime,
+            duration,
+          });
+        }
       }
       currEnd = event.endDateTime;
     }
   });
   if (currEnd.getTime() < end.getTime()) {
-    result.push({
-      startDateTime: currEnd,
-      endDateTime: end,
-      duration: getDuration(currEnd, end),
-    });
+    const duration = getDuration(currEnd, end);
+    if (duration >= minimumDuration) {
+      result.push({
+        startDateTime: currEnd,
+        endDateTime: end,
+        duration,
+      });
+    }
   }
   return result;
 }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -163,6 +163,44 @@ const accessLevelSchema = Joi.object({
   access_level: Joi.string().valid('viewer', 'regular', 'admin', 'owner').required(),
 });
 
+const scheduleProposalSchema = Joi.object({
+  title: Joi.string().max(45).required(),
+  content: Joi.string(),
+  startDateTime: Joi.date().min(getCurrentTime()).required(),
+  endDateTime: Joi.date().required(),
+  recurrence: Joi.valid(0, 1).required(),
+  freq: Joi.when('recurrence', {
+    is: 0,
+    then: Joi.valid(null).required(),
+    otherwise: Joi.string().valid('WEEKLY', 'DAILY', 'MONTHLY', 'YEARLY').required(),
+  }),
+  interval: Joi.when('recurrence', {
+    is: 0,
+    then: Joi.valid(null).required(),
+    otherwise: Joi.number().required(),
+  }),
+  byweekday: Joi.when('freq', {
+    is: 'WEEKLY',
+    then: Joi.array().items(Joi.number().min(0).max(6)).required(),
+    otherwise: Joi.valid(null).required(),
+  }),
+  until: Joi.date().allow(null).required(),
+});
+
+const scheduleProposalIdSchema = Joi.object({
+  group_id: Joi.number().min(0).required(),
+  proposal_id: Joi.number().min(0).required(),
+});
+
+const voteSchema = Joi.object({
+  attendance: Joi.boolean().valid(true, false).required(),
+});
+
+const groupSchedultConfirmSchema = Joi.object({
+  requestStartDateTime: Joi.date().required(),
+  requestEndDateTime: Joi.date().required(),
+});
+
 module.exports = {
   validateLoginSchema: validator(loginSchema),
   validateJoinSchema: validator(joinSchema),
@@ -191,4 +229,8 @@ module.exports = {
   validateUserIntroductionSchema: validator(userIntroductionSchema),
   validateGroupMemberSchema: validator(groupMemberSchema),
   validateAccessLevelSchema: validator(accessLevelSchema),
+  validateScheduleProposalSchema: validator(scheduleProposalSchema),
+  validateScheduleProposalIdSchema: validator(scheduleProposalIdSchema),
+  validateVoteSchema: validator(voteSchema),
+  validateGroupScheduleConfirmSchema: validator(groupSchedultConfirmSchema),
 };

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -98,9 +98,9 @@ const groupScheduleIdSchema = Joi.object({
 });
 
 const eventPoroposalSchema = Joi.object({
-  date1: Joi.date().min(getCurrentTime()).required(),
-  date2: Joi.date().min(getCurrentTime()),
-  date3: Joi.date().min(getCurrentTime()),
+  startDateTime: Joi.date().min(getCurrentTime()).required(),
+  endDateTime: Joi.date().min(getCurrentTime() + 60000).required(),
+  duration: Joi.number().min(0).required(),
 });
 
 const postSchema = Joi.object({
@@ -193,7 +193,7 @@ const scheduleProposalIdSchema = Joi.object({
 });
 
 const voteSchema = Joi.object({
-  attendance: Joi.boolean().valid(true, false).required(),
+  attendance: Joi.boolean().allow(1, 0, true, false).required(),
 });
 
 const groupSchedultConfirmSchema = Joi.object({


### PR DESCRIPTION
# 설명

- #176 
  - POST `/api/group/:group_id/proposal` : 그룹 일정 후보 등록
  - GET `/api/group/:group_id/proposals` : 그룹 일정 후보 시간 추천
  - GET `/api/group/:group_id/proposal/list` : 그룹 일정 후보 리스트 조회
  - GET `/api/group/:group_id/proposal/:proposal_id` : 그룹 일정 후보 단일 조회
  - DELETE `/api/group/:group_id/proposal/:proposal_id` : 그룹 일정 후보 삭제
  - POST `/api/group/:group_id/proposal/:proposal_id/vote` : 그룹 일정 후보 투표
  - POST `/api/group/:group_id/proposal/:proposal_id/confirm` : 그룹 일정 후보 확정
- #263 
  - GET `/api/group/:group_id/info` 앤드포인트를 삭제
  - GET `/api/group/:group_id` : 그룹 정보 조회 (feedCount를 추가하여, 해당 앤드포인트로 통합)
- update test code
- update swagger

# 테스트
- Integration Test
