### PR TITLE
ISSUE264-fix-get-group-list

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -1231,7 +1231,7 @@ describe('Test /api/group endpoints', () => {
     });
   });
 
-  describe('Test GET /api/group', () => {
+  describe('Test GET /api/group/list', () => {
     it('Successfully retrieved group lists. ', async () => {
       const lastRecordId = 0;
       const res = (await request(app).get('/api/group/list').set('Cookie', cookie).query({

--- a/__test__/controllers/user.test.js
+++ b/__test__/controllers/user.test.js
@@ -60,35 +60,40 @@ describe('Test /api/user endpoints', () => {
   describe('Test GET /api/user/group', () => {
     it('Successfully get a list of group', async () => {
       const res = await request(app).get('/api/user/group').set('Cookie', cookie);
-      const expectedGroups = {
-        groupList: [{
+      const expectedGroups = [
+        {
           groupId: 1,
-          leader: 1,
-          description: 'test-description1',
           name: 'test-group1',
+          description: 'test-description1',
           member: 2,
-          inviteCode: 'inviteCode01',
-          inviteExp: '2099-01-01T00:00:00.000Z',
-          isPublicGroup: 0,
-          image: 'groupImageLink',
-          UserGroup: {
-            groupId: 1, userId: 1, shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0, accessLevel: 'owner',
-          },
-        }, {
+          image: 'groupImageLink'
+        },
+        {
           groupId: 2,
-          leader: 2,
-          description: 'test-description2',
           name: 'test-group2',
+          description: 'test-description2',
           member: 6,
-          inviteCode: 'expiredCode02',
-          inviteExp: '2000-01-01T00:00:00.000Z',
-          isPublicGroup: 0,
-          image: 'groupImageLink',
-          UserGroup: {
-            groupId: 2, userId: 1, shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0, accessLevel: 'regular',
-          },
-        }],
-      };
+          image: 'groupImageLink'
+        }
+      ];
+
+      expect(res.status).toEqual(200);
+      expect(res.body).toEqual(expectedGroups);
+    });
+  });
+
+  describe('Test GET /api/user/group/pending', () => {
+    it('Successfully get a list of group', async () => {
+      const res = await request(app).get('/api/user/group/pending').set('Cookie', cookie);
+      const expectedGroups = [
+        {
+          groupId: 3,
+          name: 'test-group3',
+          description: 'test-description3',
+          member: 1,
+          image: 'groupImageLink'
+        }
+      ];
 
       expect(res.status).toEqual(200);
       expect(res.body).toEqual(expectedGroups);

--- a/__test__/dbSetup.js
+++ b/__test__/dbSetup.js
@@ -151,6 +151,11 @@ async function setUpGroupDB() {
       accessLevel: 'regular', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 0,
     },
   });
+  await user[0].addGroup(group3, {
+    through: {
+      accessLevel: 'viewer', shareScheduleOption: 1, notificationOption: 1, isPendingMember: 1,
+    },
+  });
   await user[1].addGroup(group1, {
     through: {
       accessLevel: 'admin', shareScheduleOption: 0, notificationOption: 1, isPendingMember: 0,

--- a/src/controllers/groupSchedule.js
+++ b/src/controllers/groupSchedule.js
@@ -84,6 +84,7 @@ async function getGroupSchedule(req, res, next) {
       where: {
         groupId,
         shareScheduleOption: 1,
+        isPendingMember: 0,
       },
       attributes: ['userId'],
     })).map((member) => member.userId);
@@ -125,6 +126,7 @@ async function getGroupScheduleSummary(req, res, next) {
       where: {
         groupId,
         shareScheduleOption: 1,
+        isPendingMember: 0,
       },
       attributes: ['userId'],
     })).map((member) => member.userId);

--- a/src/controllers/personalSchedule.js
+++ b/src/controllers/personalSchedule.js
@@ -93,7 +93,16 @@ async function getUserPersonalSchedule(req, res, next) {
     const end = moment.utc(endDateTime).toDate();
 
     const userSchedule = await PersonalSchedule.getSchedule([user.userId], start, end);
-    const groups = (await user.getGroups()).map((group) => group.groupId);
+    const groups = (await user.getGroups(
+      {
+        through: {
+          where: {
+            isPendingMember: 0,
+          },
+        },
+      },
+    )
+    ).map((group) => group.groupId);
     if (groups.length) {
       const groupSchedule = await GroupSchedule.getSchedule(groups, start, end);
       const response = {};
@@ -123,7 +132,16 @@ async function getUserPersonalScheduleSummary(req, res, next) {
     const end = moment.utc(endDateTime).toDate();
 
     const userSchedule = await PersonalSchedule.getSchedule([user.userId], start, end, true);
-    const groups = (await user.getGroups()).map((group) => group.groupId);
+    const groups = (await user.getGroups(
+      {
+        through: {
+          where: {
+            isPendingMember: 0,
+          },
+        },
+      },
+    )
+    ).map((group) => group.groupId);
     if (groups.length) {
       const groupSchedule = await GroupSchedule.getSchedule(groups, start, end, true);
       let response;

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -28,8 +28,42 @@ const {
 async function getUserGroup(req, res, next) {
   try {
     const { user } = req;
-    const groupList = await user.getGroups();
-    return res.status(200).json({ groupList });
+    let groups = await user.getGroups({
+      through: {
+        where: {
+          isPendingMember: 0,
+        },
+      },
+    });
+    groups = groups.map((group) => ({
+      groupId: group.groupId,
+      name: group.name,
+      description: group.description,
+      member: group.member,
+      image: group.image,
+    }));
+    return res.status(200).json(groups);
+  } catch (err) {
+    return next(new ApiError());
+  }
+}
+
+async function getPendingGroupList(req, res, next) {
+  try {
+    const { user } = req;
+    let pendingGroups = await user.getGroups({
+      where: {
+        '$UserGroup.isPendingMember$': 1,
+      },
+    });
+    pendingGroups = pendingGroups.map((group) => ({
+      groupId: group.groupId,
+      name: group.name,
+      description: group.description,
+      member: group.member,
+      image: group.image,
+    }));
+    return res.status(200).json(pendingGroups);
   } catch (err) {
     return next(new ApiError());
   }
@@ -213,6 +247,7 @@ async function patchIntroduction(req, res, next) {
 
 module.exports = {
   getUserGroup,
+  getPendingGroupList,
   patchUserProfile,
   patchUserPassword,
   withdrawal,

--- a/src/errors/group/ExceedGroupCountError.js
+++ b/src/errors/group/ExceedGroupCountError.js
@@ -1,0 +1,9 @@
+const ApiError = require('../apiError');
+
+class ExceedGroupCountError extends ApiError {
+  constructor(message) {
+    super(message || '그룹 가입/요청 수가 제한을 초과했습니다.(최대 50개)', 403);
+  }
+}
+
+module.exports = ExceedGroupCountError;

--- a/src/errors/group/index.js
+++ b/src/errors/group/index.js
@@ -2,10 +2,12 @@ const GroupNotFoundError = require('./GroupNotFoundError');
 const ExpiredCodeError = require('./ExpiredCodeError');
 const InvalidGroupJoinError = require('./InvalidGroupJoinError');
 const NoBanPermission = require('./NoBanPermission');
+const ExceedGroupCountError = require('./ExceedGroupCountError');
 
 module.exports = {
   GroupNotFoundError,
   ExpiredCodeError,
   InvalidGroupJoinError,
   NoBanPermission,
+  ExceedGroupCountError,
 };

--- a/src/middleware/token.js
+++ b/src/middleware/token.js
@@ -42,7 +42,13 @@ async function createToken(req, res, next) {
     res.cookie('accessToken', accessToken, { httpOnly: true, maxAge: 24 * 60 * 60 * 1000, secure: false });
     res.cookie('refreshToken', refreshToken, { httpOnly: true, maxAge: 24 * 60 * 60 * 1000, secure: false });
     const postCount = await Post.getUserPostCount(user.userId);
-    const groupCount = await user.countGroups();
+    const groupCount = await user.countGroups({
+      through: {
+        where: {
+          isPendingMember: 0,
+        },
+      },
+    });
     return res.status(200).json({
       userId: user.userId,
       email: user.email,
@@ -95,7 +101,13 @@ async function renewToken(req, res, next) {
     res.cookie('accessToken', accessToken, { httpOnly: true, maxAge: 24 * 60 * 60 * 1000, secure: false });
     const user = await User.findOne({ where: { nickname } });
     const postCount = await Post.getUserPostCount(user.userId);
-    const groupCount = await user.countGroups();
+    const groupCount = await user.countGroups({
+      through: {
+        where: {
+          isPendingMember: 0,
+        },
+      },
+    });
     return res.status(200).json({
       userId: user.userId,
       email: user.email,

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -3,7 +3,7 @@ const express = require('express');
 // Group
 const {
   postGroup,
-  getGroupDetail, getGroupList, getPendingGroupList,
+  getGroupDetail, getGroupList,
   putGroup, deleteGroup,
   getGroupMembers, getPendingMembers,
   postGroupJoinRequest, postGroupJoinApprove, postGroupJoinReject,
@@ -38,7 +38,6 @@ const router = express.Router();
 // Group
 router.post('/', uploadGroupMiddleware, postGroup);
 router.get('/list', getGroupList);
-router.get('/pending', getPendingGroupList);
 router.get('/search', searchGroup);
 router.get('/:group_id', getGroupDetail);
 router.put('/:group_id', uploadGroupMiddleware, putGroup);

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -3,7 +3,7 @@ const express = require('express');
 // Group
 const {
   postGroup,
-  getGroupDetail, getGroupList,
+  getGroupDetail, getGroupList, getPendingGroupList,
   putGroup, deleteGroup,
   getGroupMembers, getPendingMembers,
   postGroupJoinRequest, postGroupJoinApprove, postGroupJoinReject,
@@ -38,6 +38,7 @@ const router = express.Router();
 // Group
 router.post('/', uploadGroupMiddleware, postGroup);
 router.get('/list', getGroupList);
+router.get('/pending', getPendingGroupList);
 router.get('/search', searchGroup);
 router.get('/:group_id', getGroupDetail);
 router.put('/:group_id', uploadGroupMiddleware, putGroup);

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -4,7 +4,7 @@ const { uploadProfileMiddleware } = require('../middleware/s3');
 
 // User
 const {
-  getUserGroup,
+  getUserGroup, getPendingGroupList,
   patchUserProfile, patchUserPassword,
   getUserSetup, patchUserSetUp, patchIntroduction,
 } = require('../controllers/user');
@@ -27,6 +27,7 @@ const router = express.Router();
 
 // User
 router.get('/group', getUserGroup);
+router.get('/group/pending', getPendingGroupList);
 router.delete('/group/:group_id', deleteGroupUser);
 router.patch('/profile', uploadProfileMiddleware, patchUserProfile, createToken);
 router.patch('/profile/password', patchUserPassword);

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -2761,7 +2761,7 @@
     "/api/user/group": {
       "get": {
         "description": "",
-        "summary": "유저 그룹 조회",
+        "summary": "가입된 그룹 조회",
         "tags": ["User"],
         "responses": {
           "200": {
@@ -2770,48 +2770,64 @@
               "application/json": {
                 "examples": {
                   "successExample": {
-                    "value": {
-                      "groupList": [
-                        {
-                          "groupId": "그룹 식별자",
-                          "name": "그룹 이름",
-                          "description": "그룹 소개",
-                          "member": "멤버 수",
-                          "leader": "리더 식별자",
-                          "inviteCode": "그룹 초대 코드",
-                          "inviteExp": "초대 코드 만료일",
-                          "isPublicGroup": "BOOLEAN, 공개 그룹 여부",
-                          "image": "그룹 대표 이미지 주소",
-                          "UserGroup": {
-                            "userId": "유저 식별자",
-                            "groupId": "그룹 식별자",
-                            "shareScheduleOption": "일정 공유 여부",
-                            "notificationOption": "그룹 알림 여부",
-                            "isPendingMember": "가입 대기 여부",
-                            "accessLevel": "viewer, regular, admin, owner와 같은 접근 권한을 리턴"
-                          }
-                        },
-                        {
-                          "groupId": "그룹 식별자",
-                          "name": "그룹 이름",
-                          "description": "그룹 소개",
-                          "member": "멤버 수",
-                          "leader": "리더 식별자",
-                          "inviteCode": "그룹 초대 코드",
-                          "inviteExp": "초대 코드 만료일",
-                          "isPublicGroup": "BOOLEAN, 공개 그룹 여부",
-                          "image": "그룹 대표 이미지 주소",
-                          "UserGroup": {
-                            "userId": "유저 식별자",
-                            "groupId": "그룹 식별자",
-                            "shareScheduleOption": "일정 공유 여부",
-                            "notificationOption": "그룹 알림 여부",
-                            "isPendingMember": "가입 대기 여부",
-                            "accessLevel": "viewer, regular, admin, owner와 같은 접근 권한을 리턴"
-                          }
-                        }
-                      ]
-                    }
+                    "value": [
+                      {
+                        "groupId": "그룹 식별자",
+                        "name": "그룹 이름",
+                        "description": "그룹 소개",
+                        "member": "멤버 수",
+                        "image": "그룹 대표 이미지 주소"
+                      },
+                      {
+                        "groupId": "그룹 식별자",
+                        "name": "그룹 이름",
+                        "description": "그룹 소개",
+                        "member": "멤버 수",
+                        "image": "그룹 대표 이미지 주소"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "권한 없음"
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        }
+      }
+    },
+    "/api/user/group/pending": {
+      "get": {
+        "description": "",
+        "summary": "가입 요청 중인 그룹 조회",
+        "tags": ["User"],
+        "responses": {
+          "200": {
+            "description": "성공",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "successExample": {
+                    "value": [
+                      {
+                        "groupId": "그룹 식별자",
+                        "name": "그룹 이름",
+                        "description": "그룹 소개",
+                        "member": "멤버 수",
+                        "image": "그룹 대표 이미지 주소"
+                      },
+                      {
+                        "groupId": "그룹 식별자",
+                        "name": "그룹 이름",
+                        "description": "그룹 소개",
+                        "member": "멤버 수",
+                        "image": "그룹 대표 이미지 주소"
+                      }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
# 설명
- #264 
  - GET `/api/user/group` : 가입된 그룹 목록 조회
    - 불필요한 key-value값을 정리
    - 수정 전 response
    ![1](https://github.com/Selody-project/Backend/assets/81506668/7df93196-28b0-423b-ba08-5c2951d3f338)
    - 수정 후 response
    ![2](https://github.com/Selody-project/Backend/assets/81506668/8dee285d-a18b-47ad-8b22-3f0fc262f7c3)
  - GET `/api/user/group/pending` : 요청 중인 그룹 조회
    - 기능 추가
    - response
    ![2](https://github.com/Selody-project/Backend/assets/81506668/9a8c49b3-707e-4b8d-abc5-8ceb225db1c0)
  - 그룹 가입 시, (가입된 그룹 수+ 요청 개수)를 50개까지로 제한.
    - 가입된 그룹 수, 요청 개수를 각각 50개로 제한을 둔다면, 이미 가입된 그룹이 50개인 경우, 가입 요청 수락 처리에 대해서 따로 예외처리가 필요함. (굳이 각각 50개로 제한을 둘 이유가 있을까?)
    - 우선은 두 합을 50개로 제한하여 구현함.
  - 또한 위의 두 api는 모두 무한스크롤 방식을 따르지 않습니다. 호출 시 모든 레코드를 조회하는 방식.
- update test code
- update swagger

# 테스트
- Integration Test
