### PR TITLE
ISSUE269-fix-group-join-request

### DIFF
--- a/__test__/controllers/group.test.js
+++ b/__test__/controllers/group.test.js
@@ -142,15 +142,18 @@ describe('Test /api/group endpoints', () => {
           leaderInfo: {
             nickname: 'test-user1',
             userId: 1,
+            image: 'profileImageLink',
           },
           memberInfo: [
             {
               nickname: 'test-user1',
               userId: 1,
+              image: 'profileImageLink',
             },
             {
               nickname: 'test-user2',
               userId: 2,
+              image: 'profileImageLink',
             },
           ],
         },
@@ -819,8 +822,13 @@ describe('Test /api/group endpoints', () => {
   describe('Test POST /api/group/:group_id/members/request', () => {
     it('Successfully completed the application for registration.  ', async () => {
       const groupId = 4;
-      const res = (await request(app).post(`/api/group/${groupId}/members/request`).set('Cookie', cookie));
+      let res = (await request(app).post(`/api/group/${groupId}/members/request`).set('Cookie', cookie));
+      expect(res.body).toEqual({ message: '성공적으로 신청되었습니다.' });
       expect(res.status).toEqual(200);
+      
+      res = (await request(app).post(`/api/group/${groupId}/members/request`).set('Cookie', cookie));
+      expect(res.body).toEqual({ message: '성공적으로 취소되었습니다.' });
+      expect(res.status).toEqual(200); 
     });
 
     it('Successfully failed to complete the application for registration. (Group Not Found) ', async () => {
@@ -1525,13 +1533,13 @@ describe('Test /api/group endpoints', () => {
         {
           accessLevel: 'owner',
           member: {
-            isPendingMember: 0, nickname: 'test-user1', userId: 1,
+            isPendingMember: 0, nickname: 'test-user1', userId: 1, image: 'profileImageLink',
           },
         },
         {
           accessLevel: 'admin',
           member: {
-            isPendingMember: 0, nickname: 'test-user2', userId: 2,
+            isPendingMember: 0, nickname: 'test-user2', userId: 2, image: 'profileImageLink',
           },
         },
       ];
@@ -1562,7 +1570,7 @@ describe('Test /api/group endpoints', () => {
         {
           accessLevel: 'viewer',
           member: {
-            isPendingMember: 1, nickname: 'test-user5', userId: 5,
+            isPendingMember: 1, nickname: 'test-user5', userId: 5, image: 'profileImageLink',
           },
         },
       ];

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -99,6 +99,7 @@ async function getGoogleUserInfo(req, res, next) {
 async function joinSocialUser(req, res, next) {
   let transaction;
   try {
+    transaction = await sequelize.transaction();
     const user = await User.findOne({ where: { email: req.body.email }, transaction });
     if (!user) {
       const nickname = `naver-${req.body.id}`.slice(0, 15);
@@ -135,6 +136,7 @@ async function joinSocialUser(req, res, next) {
 async function join(req, res, next) {
   let transaction;
   try {
+    transaction = await sequelize.transaction();
     const { error: bodyError } = validateJoinSchema(req.body);
     if (bodyError) {
       throw (new DataFormatError());
@@ -162,6 +164,7 @@ async function join(req, res, next) {
         provider: 'local',
       });
       req.nickname = nickname;
+      await transaction.commit();
       return next();
     }
 

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -500,16 +500,19 @@
                         },
                         "leaderInfo": {
                           "userId": "유저 식별자",
-                          "nickname": "유저 닉네임"
+                          "nickname": "유저 닉네임",
+                          "image": "유저 프로필 이미지"
                         },
                         "memberInfo": [
                           {
                             "userId": "유저 식별자",
-                            "nickname": "유저 닉네임"
+                            "nickname": "유저 닉네임",
+                            "image": "유저 프로필 이미지"
                           },
                           {
                             "userId": "유저 식별자",
-                            "nickname": "유저 닉네임"
+                            "nickname": "유저 닉네임",
+                            "image": "유저 프로필 이미지"
                           }
                         ]
                       }
@@ -666,6 +669,7 @@
                         "member": {
                           "userId": "유저 식별자",
                           "nickname": "유저 닉네임",
+                          "image": "유저 프로필 이미지",
                           "isPendingMember": 0
                         }
                       },
@@ -674,6 +678,7 @@
                         "member": { 
                           "userId": "유저 식별자",
                           "nickname": "유저 닉네임",
+                          "image": "유저 프로필 이미지",
                           "isPendingMember": 0
                         }
                       }
@@ -724,6 +729,7 @@
                         "member": {
                           "userId": "유저 식별자",
                           "nickname": "유저 닉네임",
+                          "image": "유저 프로필 이미지",
                           "isPendingMember": 1
                         }
                       },
@@ -732,6 +738,7 @@
                         "member": {
                           "userId": "유저 식별자",
                           "nickname": "유저 닉네임",
+                          "image": "유저 프로필 이미지",
                           "isPendingMember": 1
                         }
                       }
@@ -756,8 +763,8 @@
         }
       },
       "post": {
-        "description": "",
-        "summary": "그룹 가입 신청",
+        "description": "이미 가입 신청이 되어 있는 경우에는 api 호출 시, 신청이 취소됩니다.",
+        "summary": "그룹 가입 신청 또는 취소",
         "tags": ["Group"],
         "parameters": [
           {


### PR DESCRIPTION
# 설명
- #269 
  - POST `/api/group/:group_id/members/request` : 그룹 신청 및 취소
  - 이미 신청이 되어 있는 상태라면 취소되고, 아니라면 신청됨
- 아래의 api에서 유저 프로필 이미지를 response에 추가
  - GET `/api/group/{group_id}` : 단일 그룹 정보 상세 조회
  - GET `/api/group/{group_id}/members` : 그룹 멤버 리스트 조회
  - GET `/api/group/{group_id}/members/request` : 가입 대기중인 유저 조회
- update test code
- update swagger

# 테스트
- Integration Test
