### PR TITLE
add newPasswordCheckBody in swagger api docs

### DIFF
--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -3108,8 +3108,8 @@
                                         "example": "new_strong_password",
                                         "type": "VARCHAR(100)"
                                     },
-                                    "newPassword": {
-                                        "example": "new_strong_password",
+                                    "newPasswordCheck": {
+                                        "example": "new_strong_passwordCheck",
                                         "type": "VARCHAR(100)"
                                     }
                                 }


### PR DESCRIPTION
실수로 중복 작성한 swagger docs의 `newPassord` body를 `newPasswordCheck`로 변경합니다
